### PR TITLE
Improve moderator access caching and status badge styling

### DIFF
--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -4,6 +4,8 @@ import test from 'node:test';
 import {
   clearExpiredPendingClaim,
   ensureUserValidationSchedule,
+  getCurrentModeratorPermissionList,
+  getModeratorAccessSnapshot,
   normalizeSubmittedPhotoUrl,
   releaseRedisLockIfOwned,
   toPublicHubConfig,
@@ -172,6 +174,101 @@ function createRedisLockContext(initialValue: string | null) {
   };
 }
 
+function createModeratorLookupContext(options?: {
+  subredditId?: string;
+  currentUsername?: string | null;
+  permissionResponses?: Array<string[] | Error>;
+  broadModeratorResponses?: Array<Array<{ username: string }> | Error>;
+  filteredModeratorResponses?: Array<Array<{ username: string }> | Error>;
+}) {
+  const redisStore = new Map<string, string>();
+  const permissionResponses = options?.permissionResponses ?? [];
+  const broadModeratorResponses = options?.broadModeratorResponses ?? [];
+  const filteredModeratorResponses = options?.filteredModeratorResponses ?? [];
+  let permissionCallCount = 0;
+  let broadCallCount = 0;
+  let filteredCallCount = 0;
+
+  const nextPermissionResponse = (): string[] => {
+    const response = permissionResponses[Math.min(permissionCallCount, permissionResponses.length - 1)];
+    permissionCallCount += 1;
+    if (response instanceof Error) {
+      throw response;
+    }
+    return Array.isArray(response) ? response : [];
+  };
+
+  const nextModeratorsResponse = (
+    responses: Array<Array<{ username: string }> | Error>,
+    kind: 'broad' | 'filtered'
+  ): Array<{ username: string }> => {
+    if (kind === 'broad') {
+      broadCallCount += 1;
+    } else {
+      filteredCallCount += 1;
+    }
+    const index = kind === 'broad' ? broadCallCount - 1 : filteredCallCount - 1;
+    const response = responses[Math.min(index, responses.length - 1)];
+    if (response instanceof Error) {
+      throw response;
+    }
+    return Array.isArray(response) ? response : [];
+  };
+
+  return {
+    context: {
+      subredditId: options?.subredditId ?? 't5_example',
+      reddit: {
+        async getCurrentUsername() {
+          return options?.currentUsername ?? 'mod_one';
+        },
+        async getCurrentUser() {
+          return {
+            async getModPermissionsForSubreddit() {
+              return nextPermissionResponse();
+            },
+          };
+        },
+        getModerators(args: { username?: string }) {
+          return {
+            async all() {
+              return args.username
+                ? nextModeratorsResponse(filteredModeratorResponses, 'filtered')
+                : nextModeratorsResponse(broadModeratorResponses, 'broad');
+            },
+          };
+        },
+      },
+      redis: {
+        async set(key: string, value: string, options?: { nx?: boolean }) {
+          if (options?.nx && redisStore.has(key)) {
+            return null;
+          }
+          redisStore.set(key, value);
+          return 'OK';
+        },
+        async get(key: string) {
+          return redisStore.get(key) ?? null;
+        },
+        async del(...keys: string[]) {
+          for (const key of keys) {
+            redisStore.delete(key);
+          }
+        },
+      },
+    },
+    get permissionCallCount() {
+      return permissionCallCount;
+    },
+    get broadCallCount() {
+      return broadCallCount;
+    },
+    get filteredCallCount() {
+      return filteredCallCount;
+    },
+  };
+}
+
 test('normalizeSubmittedPhotoUrl accepts Reddit-hosted upload URLs', () => {
   assert.equal(
     normalizeSubmittedPhotoUrl('https://i.redd.it/example-photo.png'),
@@ -187,6 +284,46 @@ test('normalizeSubmittedPhotoUrl rejects non-Reddit or non-https URLs', () => {
   assert.equal(normalizeSubmittedPhotoUrl('https://example.com/photo.png'), null);
   assert.equal(normalizeSubmittedPhotoUrl('http://i.redd.it/photo.png'), null);
   assert.equal(normalizeSubmittedPhotoUrl('javascript:alert(1)'), null);
+});
+
+test('getCurrentModeratorPermissionList reuses cached permissions after a transient lookup failure', async () => {
+  const lookupContext = createModeratorLookupContext({
+    permissionResponses: [['access', 'config'], new Error('reddit 500')],
+  });
+
+  const first = await getCurrentModeratorPermissionList(lookupContext.context as never, 'ExampleSub', 'mod_one');
+  const second = await getCurrentModeratorPermissionList(lookupContext.context as never, 'ExampleSub', 'mod_one');
+
+  assert.deepEqual(first, ['access', 'config']);
+  assert.deepEqual(second, ['access', 'config']);
+  assert.equal(lookupContext.permissionCallCount, 2);
+  assert.equal(lookupContext.broadCallCount, 0);
+  assert.equal(lookupContext.filteredCallCount, 0);
+});
+
+test('getModeratorAccessSnapshot falls back to cached moderator role when moderator listings fail', async () => {
+  const lookupContext = createModeratorLookupContext({
+    permissionResponses: [new Error('reddit 500'), new Error('reddit 500')],
+    broadModeratorResponses: [[{ username: 'mod_one' }], new Error('reddit 500')],
+    filteredModeratorResponses: [new Error('reddit 500')],
+  });
+  const originalConsoleLog = console.log;
+  console.log = () => {};
+
+  try {
+    const first = await getModeratorAccessSnapshot(lookupContext.context as never, 'ExampleSub', 'mod_one');
+    const second = await getModeratorAccessSnapshot(lookupContext.context as never, 'ExampleSub', 'mod_one');
+
+    assert.equal(first.isModerator, true);
+    assert.deepEqual(first.permissions, []);
+    assert.equal(second.isModerator, true);
+    assert.deepEqual(second.permissions, []);
+    assert.equal(lookupContext.permissionCallCount, 2);
+    assert.equal(lookupContext.broadCallCount, 2);
+    assert.equal(lookupContext.filteredCallCount, 1);
+  } finally {
+    console.log = originalConsoleLog;
+  }
 });
 
 test('clearExpiredPendingClaim clears stale claims', () => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -181,6 +181,11 @@ type ViewerFlairSnapshot = {
   userId: string;
 };
 
+type ModeratorAccessSnapshot = {
+  isModerator: boolean;
+  permissions: string[];
+};
+
 type SubmitVerificationValues = {
   is18Confirmed: boolean;
   adultOnlySelfPhotosConfirmed: boolean;
@@ -510,6 +515,9 @@ const DENY_REASON_INSTALL_SETTINGS: readonly DenyReasonSlotDefinition[] = [
   },
 ] as const;
 const MODMAIL_DEDUPE_TTL_SECONDS = 7 * 24 * 60 * 60;
+const MODERATOR_PERMISSION_CACHE_TTL_MS = 15 * 60 * 1000;
+const MODERATOR_ROLE_CACHE_TTL_MS = 15 * 60 * 1000;
+const MODERATOR_LOOKUP_LOG_COOLDOWN_MS = 15 * 60 * 1000;
 const USER_VALIDATION_CRON = '30 3 * * *';
 const USER_VALIDATION_JOB_NAME = `${APP_KEY_PREFIX}:user-validation-reconcile`;
 const USER_VALIDATION_SCHEDULE_LOCK_TTL_MS = 15000;
@@ -2678,10 +2686,11 @@ async function loadDashboardData(
   const subredditName = await getCurrentSubredditNameCompat(context);
   await ensureUserValidationSchedule(context, subredditId, subredditName);
   const viewerUsername = (await context.reddit.getCurrentUsername()) ?? null;
-  const isModeratorUser = viewerUsername ? await isModerator(context, subredditName, viewerUsername) : false;
-  const moderatorPermissions = viewerUsername
-    ? await getCurrentModeratorPermissionList(context, subredditName, viewerUsername)
-    : [];
+  const moderatorAccess = viewerUsername
+    ? await getModeratorAccessSnapshot(context, subredditName, viewerUsername)
+    : { isModerator: false, permissions: [] };
+  const isModeratorUser = moderatorAccess.isModerator;
+  const moderatorPermissions = moderatorAccess.permissions;
   const canManageUsers = hasManageUsersPermissionInList(moderatorPermissions);
   const settingsTabRequiresConfigAccess = await getSettingsTabRequiresConfigAccess(context);
   const canOpenInstallSettings = hasAllModeratorPermissionInList(moderatorPermissions);
@@ -4270,45 +4279,71 @@ async function setRecord(context: RedisContext, subredditId: string, record: Ver
   });
 }
 
-async function isModerator(
+async function getModeratorAccessSnapshot(
   context: Devvit.Context,
   subredditName: string,
   username: string
-): Promise<boolean> {
+): Promise<ModeratorAccessSnapshot> {
   const sanitizedSubreddit = sanitizeSubredditName(subredditName);
-
-  try {
-    const currentUsername = await context.reddit.getCurrentUsername();
-    if (currentUsername && normalizeUsername(currentUsername) === normalizeUsername(username)) {
-      const currentUser = await context.reddit.getCurrentUser();
-      if (currentUser) {
-        const permissions = await currentUser.getModPermissionsForSubreddit(sanitizedSubreddit);
-        if (permissions.length > 0) {
-          return true;
-        }
-      }
-    }
-  } catch (error) {
-    console.log(`Mod permission lookup failed (user permissions path): ${errorText(error)}`);
+  const permissions = await getCurrentModeratorPermissionList(context, sanitizedSubreddit, username);
+  if (permissions.length > 0) {
+    return {
+      isModerator: true,
+      permissions,
+    };
   }
 
+  const normalizedUsername = normalizeUsername(username);
+  const errors: string[] = [];
+
   try {
-    const normalizedUsername = normalizeUsername(username);
     const mods = await context.reddit.getModerators({ subredditName: sanitizedSubreddit, limit: 100 }).all();
-    return mods.some((modUser) => normalizeUsername(modUser.username) === normalizedUsername);
+    if (mods.some((modUser) => normalizeUsername(modUser.username) === normalizedUsername)) {
+      await cacheModeratorRole(context, username);
+      return {
+        isModerator: true,
+        permissions,
+      };
+    }
   } catch (error) {
-    console.log(`Mod permission lookup failed (broad moderators listing path): ${errorText(error)}`);
+    errors.push(`broad moderators listing path: ${errorText(error)}`);
   }
 
   try {
     const mods = await context.reddit
       .getModerators({ subredditName: sanitizedSubreddit, username, limit: 1 })
       .all();
-    return mods.some((modUser) => normalizeUsername(modUser.username) === normalizeUsername(username));
+    if (mods.some((modUser) => normalizeUsername(modUser.username) === normalizedUsername)) {
+      await cacheModeratorRole(context, username);
+      return {
+        isModerator: true,
+        permissions,
+      };
+    }
   } catch (error) {
-    console.log(`Mod permission lookup failed (moderators listing path): ${errorText(error)}`);
-    return false;
+    errors.push(`moderators listing path: ${errorText(error)}`);
   }
+
+  if (await getCachedModeratorRole(context, username)) {
+    return {
+      isModerator: true,
+      permissions,
+    };
+  }
+
+  if (errors.length > 0) {
+    await logModeratorLookupFailureWithCooldown(
+      context,
+      'membership',
+      username,
+      `Moderator membership lookup failed for r/${sanitizedSubreddit} u/${maskUsernameForLog(username)}: ${errors.join(' | ')}`
+    );
+  }
+
+  return {
+    isModerator: false,
+    permissions,
+  };
 }
 
 async function assertCanReview(
@@ -4344,14 +4379,25 @@ async function getCurrentModeratorPermissionList(
   try {
     const currentUser = await context.reddit.getCurrentUser();
     if (!currentUser) {
-      return [];
+      return await getCachedModeratorPermissions(context, username);
     }
-    return await currentUser.getModPermissionsForSubreddit(sanitizedSubreddit);
+    const permissions = normalizeModeratorPermissions(
+      await currentUser.getModPermissionsForSubreddit(sanitizedSubreddit)
+    );
+    await cacheModeratorPermissions(context, username, permissions);
+    return permissions;
   } catch (error) {
-    console.log(
+    const cachedPermissions = await getCachedModeratorPermissions(context, username);
+    if (cachedPermissions.length > 0) {
+      return cachedPermissions;
+    }
+    await logModeratorLookupFailureWithCooldown(
+      context,
+      'permissions',
+      username,
       `Moderator permission lookup failed for r/${sanitizedSubreddit} u/${maskUsernameForLog(username)}: ${errorText(error)}`
     );
-    return [];
+    return cachedPermissions;
   }
 }
 
@@ -4377,26 +4423,8 @@ async function hasManageUsersPermission(
   subredditName: string,
   username: string
 ): Promise<boolean> {
-  const sanitizedSubreddit = sanitizeSubredditName(subredditName);
-  const normalizedUsername = normalizeUsername(username);
-  const currentUsername = await context.reddit.getCurrentUsername();
-  if (!currentUsername || normalizeUsername(currentUsername) !== normalizedUsername) {
-    return false;
-  }
-
-  try {
-    const currentUser = await context.reddit.getCurrentUser();
-    if (!currentUser) {
-      return false;
-    }
-    const permissions = await currentUser.getModPermissionsForSubreddit(sanitizedSubreddit);
-    return hasManageUsersPermissionInList(permissions);
-  } catch (error) {
-    console.log(
-      `Manage Users permission lookup failed for r/${sanitizedSubreddit} u/${maskUsernameForLog(username)}: ${errorText(error)}`
-    );
-    return false;
-  }
+  const permissions = await getCurrentModeratorPermissionList(context, subredditName, username);
+  return hasManageUsersPermissionInList(permissions);
 }
 
 async function hasConfigAccessPermission(
@@ -4404,26 +4432,8 @@ async function hasConfigAccessPermission(
   subredditName: string,
   username: string
 ): Promise<boolean> {
-  const sanitizedSubreddit = sanitizeSubredditName(subredditName);
-  const normalizedUsername = normalizeUsername(username);
-  const currentUsername = await context.reddit.getCurrentUsername();
-  if (!currentUsername || normalizeUsername(currentUsername) !== normalizedUsername) {
-    return false;
-  }
-
-  try {
-    const currentUser = await context.reddit.getCurrentUser();
-    if (!currentUser) {
-      return false;
-    }
-    const permissions = await currentUser.getModPermissionsForSubreddit(sanitizedSubreddit);
-    return hasConfigAccessPermissionInList(permissions);
-  } catch (error) {
-    console.log(
-      `Config access permission lookup failed for r/${sanitizedSubreddit} u/${maskUsernameForLog(username)}: ${errorText(error)}`
-    );
-    return false;
-  }
+  const permissions = await getCurrentModeratorPermissionList(context, subredditName, username);
+  return hasConfigAccessPermissionInList(permissions);
 }
 
 async function hasAllModeratorPermission(
@@ -4431,26 +4441,8 @@ async function hasAllModeratorPermission(
   subredditName: string,
   username: string
 ): Promise<boolean> {
-  const sanitizedSubreddit = sanitizeSubredditName(subredditName);
-  const normalizedUsername = normalizeUsername(username);
-  const currentUsername = await context.reddit.getCurrentUsername();
-  if (!currentUsername || normalizeUsername(currentUsername) !== normalizedUsername) {
-    return false;
-  }
-
-  try {
-    const currentUser = await context.reddit.getCurrentUser();
-    if (!currentUser) {
-      return false;
-    }
-    const permissions = await currentUser.getModPermissionsForSubreddit(sanitizedSubreddit);
-    return hasAllModeratorPermissionInList(permissions);
-  } catch (error) {
-    console.log(
-      `All moderator permission lookup failed for r/${sanitizedSubreddit} u/${maskUsernameForLog(username)}: ${errorText(error)}`
-    );
-    return false;
-  }
+  const permissions = await getCurrentModeratorPermissionList(context, subredditName, username);
+  return hasAllModeratorPermissionInList(permissions);
 }
 
 function hasManageUsersPermissionInList(permissions: string[]): boolean {
@@ -5090,6 +5082,18 @@ function modmailLockKey(subredditId: string, eventId: string): string {
   return `${subredditScopePrefix(subredditId)}:modmail:lock:${eventId}`;
 }
 
+function moderatorPermissionCacheKey(subredditId: string, username: string): string {
+  return `${subredditScopePrefix(subredditId)}:moderator:permissions:${normalizeUsername(username)}`;
+}
+
+function moderatorRoleCacheKey(subredditId: string, username: string): string {
+  return `${subredditScopePrefix(subredditId)}:moderator:role:${normalizeUsername(username)}`;
+}
+
+function moderatorLookupLogCooldownKey(subredditId: string, scope: string, username: string): string {
+  return `${subredditScopePrefix(subredditId)}:moderator:lookup-log:${scope}:${normalizeUsername(username) || 'unknown'}`;
+}
+
 function sanitizeSubredditId(input: string): string {
   return input.trim().toLowerCase();
 }
@@ -5124,6 +5128,133 @@ async function getCurrentSubredditNameCompat(
 
 function normalizeUsername(input: string): string {
   return input.trim().replace(/^u\//i, '').toLowerCase();
+}
+
+function normalizeModeratorPermissions(permissions: string[]): string[] {
+  return dedupeNonEmpty(permissions.map((permission) => String(permission ?? '').trim()));
+}
+
+function getModeratorCacheSubredditId(context: { subredditId?: string | null }): string {
+  return sanitizeSubredditId(typeof context.subredditId === 'string' ? context.subredditId : '');
+}
+
+async function cacheModeratorRole(
+  context: Pick<Devvit.Context, 'redis'> & { subredditId?: string | null },
+  username: string
+): Promise<void> {
+  const subredditId = getModeratorCacheSubredditId(context);
+  const normalizedUsername = normalizeUsername(username);
+  if (!subredditId || !normalizedUsername) {
+    return;
+  }
+
+  try {
+    await context.redis.set(moderatorRoleCacheKey(subredditId, normalizedUsername), '1', {
+      expiration: new Date(Date.now() + MODERATOR_ROLE_CACHE_TTL_MS),
+    });
+  } catch {
+    // Best-effort cache only.
+  }
+}
+
+async function getCachedModeratorRole(
+  context: Pick<Devvit.Context, 'redis'> & { subredditId?: string | null },
+  username: string
+): Promise<boolean> {
+  const subredditId = getModeratorCacheSubredditId(context);
+  const normalizedUsername = normalizeUsername(username);
+  if (!subredditId || !normalizedUsername) {
+    return false;
+  }
+
+  try {
+    return Boolean(await context.redis.get(moderatorRoleCacheKey(subredditId, normalizedUsername)));
+  } catch {
+    return false;
+  }
+}
+
+async function cacheModeratorPermissions(
+  context: Pick<Devvit.Context, 'redis'> & { subredditId?: string | null },
+  username: string,
+  permissions: string[]
+): Promise<void> {
+  const subredditId = getModeratorCacheSubredditId(context);
+  const normalizedUsername = normalizeUsername(username);
+  const normalizedPermissions = normalizeModeratorPermissions(permissions);
+  if (!subredditId || !normalizedUsername || normalizedPermissions.length === 0) {
+    return;
+  }
+
+  try {
+    await context.redis.set(
+      moderatorPermissionCacheKey(subredditId, normalizedUsername),
+      JSON.stringify(normalizedPermissions),
+      {
+        expiration: new Date(Date.now() + MODERATOR_PERMISSION_CACHE_TTL_MS),
+      }
+    );
+  } catch {
+    // Best-effort cache only.
+  }
+
+  await cacheModeratorRole(context, normalizedUsername);
+}
+
+async function getCachedModeratorPermissions(
+  context: Pick<Devvit.Context, 'redis'> & { subredditId?: string | null },
+  username: string
+): Promise<string[]> {
+  const subredditId = getModeratorCacheSubredditId(context);
+  const normalizedUsername = normalizeUsername(username);
+  if (!subredditId || !normalizedUsername) {
+    return [];
+  }
+
+  try {
+    const payload = await context.redis.get(moderatorPermissionCacheKey(subredditId, normalizedUsername));
+    if (!payload) {
+      return [];
+    }
+    const parsed = JSON.parse(payload) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return normalizeModeratorPermissions(parsed.filter((value): value is string => typeof value === 'string'));
+  } catch {
+    return [];
+  }
+}
+
+async function logModeratorLookupFailureWithCooldown(
+  context: Pick<Devvit.Context, 'redis'> & { subredditId?: string | null },
+  scope: string,
+  username: string,
+  message: string
+): Promise<void> {
+  const subredditId = getModeratorCacheSubredditId(context);
+  const normalizedUsername = normalizeUsername(username);
+  if (!subredditId || !normalizedUsername) {
+    return;
+  }
+
+  try {
+    const shouldLog = await context.redis.set(
+      moderatorLookupLogCooldownKey(subredditId, scope, normalizedUsername),
+      '1',
+      {
+        nx: true,
+        expiration: new Date(Date.now() + MODERATOR_LOOKUP_LOG_COOLDOWN_MS),
+      }
+    );
+    if (shouldLog !== 'OK') {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  console.log(message);
 }
 
 function approvedPrefixFromUsername(username: string): string {
@@ -6219,6 +6350,8 @@ export {
   searchHistoryRecords,
   searchApprovedRecords,
   searchAuditEntries,
+  getCurrentModeratorPermissionList,
+  getModeratorAccessSnapshot,
   unblockUserForModerator,
   blockUserForModerator,
   onSaveFlairTemplateValues,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   deleteVerificationDataFormDefinition,
   denyVerification,
   errorText,
+  getModeratorAccessSnapshot,
   getCurrentSubredditNameCompat,
   loadHubDashboard,
   loadModDashboard,
@@ -125,20 +126,8 @@ async function requireModerator(appContext: Devvit.Context): Promise<{ moderator
   }
 
   const subredditName = await getCurrentSubredditNameCompat(appContext);
-
-  try {
-    const currentUser = await appContext.reddit.getCurrentUser();
-    if (!currentUser) {
-      throw httpError(403, 'You must be logged in as a moderator.');
-    }
-    const permissions = await currentUser.getModPermissionsForSubreddit(subredditName);
-    if (!Array.isArray(permissions) || permissions.length === 0) {
-      throw httpError(403, 'Only moderators can create verification posts.');
-    }
-  } catch (error) {
-    if (getStatus(error) === 403) {
-      throw error;
-    }
+  const access = await getModeratorAccessSnapshot(appContext, subredditName, moderator);
+  if (!access.isModerator) {
     throw httpError(403, 'Only moderators can create verification posts.');
   }
 

--- a/webroot/hub-app.js
+++ b/webroot/hub-app.js
@@ -755,25 +755,27 @@ export function mountHub(options = {}) {
 
     refs.metaStatus.className = 'status-line';
     let statusText = 'Not verified';
+    let statusClass = 'status-neutral';
     if (state.viewerVerifiedByFlair) {
       statusText = isManualSource(state.viewerFlairCheckSource) ? 'Verified (Manual)' : 'Verified';
-      refs.metaStatus.classList.add('status-verified');
+      statusClass = 'status-verified';
     } else if (isRestricted) {
       statusText = 'Blocked';
-      refs.metaStatus.classList.add('status-blocked');
+      statusClass = 'status-blocked';
     } else if (state.userLatest?.status === 'pending' && state.userLatest?.parentVerificationId) {
       statusText = 'Pending Re-review';
-      refs.metaStatus.classList.add('status-warning');
+      statusClass = 'status-warning';
     } else if (state.userLatest?.status === 'pending') {
       statusText = 'Pending Review';
-      refs.metaStatus.classList.add('status-warning');
+      statusClass = 'status-warning';
     } else if (state.userLatest?.status === 'denied') {
       statusText = 'Denied - Resubmit';
-      refs.metaStatus.classList.add('status-danger');
+      statusClass = 'status-danger';
     } else if (state.userLatest?.status === 'removed') {
       statusText = 'Verification Removed';
-      refs.metaStatus.classList.add('status-danger');
+      statusClass = 'status-danger';
     }
+    refs.metaStatus.classList.add(statusClass);
     refs.metaStatus.textContent = statusText;
 
     refs.pendingBadge.textContent = state.pendingCount > 99 ? '99+' : String(state.pendingCount || 0);

--- a/webroot/hub-ui.css
+++ b/webroot/hub-ui.css
@@ -241,14 +241,33 @@ h2 {
   margin: 0;
   display: inline-flex;
   align-items: center;
-  min-height: 38px;
-  padding: 0 14px;
-  border-radius: 999px;
+  gap: 10px;
+  min-height: 0;
+  padding: 9px 12px 9px 10px;
+  border-radius: 14px;
   border: 1px solid color-mix(in srgb, var(--line) 78%, transparent);
-  background: color-mix(in srgb, var(--card) 70%, var(--bg) 30%);
-  font-size: 0.92rem;
-  font-weight: 800;
+  background: color-mix(in srgb, var(--card) 68%, var(--bg) 32%);
+  color: color-mix(in srgb, var(--text) 52%, var(--muted) 48%);
+  font-size: 0.9rem;
+  font-weight: 700;
   white-space: nowrap;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.status-line::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 12%, transparent);
+  flex: 0 0 auto;
+}
+
+.status-neutral {
+  border-style: dashed;
+  background: color-mix(in srgb, var(--card) 58%, var(--bg) 42%);
+  color: color-mix(in srgb, var(--muted) 86%, var(--text) 14%);
 }
 
 .status-verified {


### PR DESCRIPTION
**Summary**
- cache moderator permissions/role lookups, fall back to cached membership, and log failures with cooldown to stabilize dashboard access control
- use the new access snapshot everywhere the UI needs moderator info, reducing redundant permission checks
- refactor status line rendering into reusable CSS classes and consolidated DOM updates to keep hub UI badges in sync with state

**Testing**
- Not run (not requested)