### PR TITLE
Add localized photo instruction controls and default language settings

### DIFF
--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -13,6 +13,7 @@ import {
   ensureUserValidationSchedule,
   getCurrentModeratorPermissionList,
   getHubModeratorUiState,
+  getRuntimeConfig,
   getModeratorAccessSnapshot,
   getModeratorStats,
   getViewerFlairSnapshot,
@@ -104,6 +105,9 @@ function buildRuntimeConfig(): RuntimeConfig {
     maxDenialsBeforeBlock: 3,
     requiredPhotoCount: 2,
     photoInstructions: 'Follow the instructions.',
+    photoInstructionsEs: 'Sigue las instrucciones.',
+    photoInstructionsFr: 'Suivez les instructions.',
+    photoInstructionsDefaultLanguage: 'en',
     showPhotoInstructionsBeforeSubmit: true,
     denyReasons: [
       {
@@ -1908,6 +1912,64 @@ test('onSaveFlairTemplateValues preserves verificationsEnabled when it is omitte
 
   assert.equal(saveContext.hashStore.get(saveContext.configKey)?.get('verifications_enabled'), 'false');
   assert.ok(saveContext.setFieldsCalls.every((entries) => !('verifications_enabled' in entries)));
+});
+
+test('onSaveFlairTemplateValues saves translated photo instructions with the primary instructions', async () => {
+  const saveContext = createFlairSettingsSaveContext({
+    storedConfig: {
+      flair_template_id: 'ABC-123',
+    },
+  });
+
+  await onSaveFlairTemplateValues(
+    {
+      flairTemplateId: 'ABC-123',
+      flairCssClass: '',
+      requiredPhotoCount: 2,
+      photoInstructionsDefaultLanguage: 'fr',
+      photoInstructions: '  Follow the instructions.  ',
+      photoInstructionsEs: '  Sigue las instrucciones.  ',
+      photoInstructionsFr: '  Suivez les instructions.  ',
+    },
+    saveContext.context as never
+  );
+
+  assert.equal(saveContext.hashStore.get(saveContext.configKey)?.get('photo_instructions'), 'Follow the instructions.');
+  assert.equal(saveContext.hashStore.get(saveContext.configKey)?.get('photo_instructions_es'), 'Sigue las instrucciones.');
+  assert.equal(saveContext.hashStore.get(saveContext.configKey)?.get('photo_instructions_fr'), 'Suivez les instructions.');
+  assert.equal(saveContext.hashStore.get(saveContext.configKey)?.get('photo_instructions_default_language'), 'fr');
+});
+
+test('getRuntimeConfig reads translated photo instructions from stored settings', async () => {
+  const saveContext = createFlairSettingsSaveContext({
+    storedConfig: {
+      photo_instructions: 'Follow the instructions.',
+      photo_instructions_es: 'Sigue las instrucciones.',
+      photo_instructions_fr: '  Suivez les instructions.  ',
+      photo_instructions_default_language: 'fr',
+    },
+  });
+
+  const runtimeConfig = await getRuntimeConfig(saveContext.context as never, 't5_example');
+
+  assert.equal(runtimeConfig.photoInstructions, 'Follow the instructions.');
+  assert.equal(runtimeConfig.photoInstructionsEs, 'Sigue las instrucciones.');
+  assert.equal(runtimeConfig.photoInstructionsFr, 'Suivez les instructions.');
+  assert.equal(runtimeConfig.photoInstructionsDefaultLanguage, 'fr');
+});
+
+test('getRuntimeConfig defaults translated photo instructions to empty strings and english default language when unset', async () => {
+  const saveContext = createFlairSettingsSaveContext({
+    storedConfig: {
+      photo_instructions: 'Follow the instructions.',
+    },
+  });
+
+  const runtimeConfig = await getRuntimeConfig(saveContext.context as never, 't5_example');
+
+  assert.equal(runtimeConfig.photoInstructionsEs, '');
+  assert.equal(runtimeConfig.photoInstructionsFr, '');
+  assert.equal(runtimeConfig.photoInstructionsDefaultLanguage, 'en');
 });
 
 test('onSaveFlairTemplateValues still updates verificationsEnabled when explicitly provided', async () => {
@@ -3875,6 +3937,9 @@ test('toPublicHubConfig omits moderator-only template content', () => {
     verificationsEnabled: true,
     verificationsDisabledMessage: 'Disabled',
     photoInstructions: 'Follow the instructions.',
+    photoInstructionsEs: 'Sigue las instrucciones.',
+    photoInstructionsFr: 'Suivez les instructions.',
+    photoInstructionsDefaultLanguage: 'en',
     showPhotoInstructionsBeforeSubmit: true,
     pendingTurnaroundDays: 3,
     denyReasons: [

--- a/src/core.ts
+++ b/src/core.ts
@@ -99,6 +99,9 @@ type RuntimeConfig = {
   maxDenialsBeforeBlock: number;
   requiredPhotoCount: number;
   photoInstructions: string;
+  photoInstructionsEs: string;
+  photoInstructionsFr: string;
+  photoInstructionsDefaultLanguage: string;
   showPhotoInstructionsBeforeSubmit: boolean;
   denyReasons: DenyReasonConfig[];
   pendingTurnaroundDays: number;
@@ -355,6 +358,9 @@ type FlairTemplateFormValues = {
   verificationsEnabled?: boolean;
   requiredPhotoCount?: number;
   photoInstructions?: string;
+  photoInstructionsEs?: string;
+  photoInstructionsFr?: string;
+  photoInstructionsDefaultLanguage?: string;
   flairTemplateId?: string;
   flairCssClass?: string;
   multipleApprovalFlairsEnabled?: boolean;
@@ -559,6 +565,9 @@ type PublicHubConfig = {
   verificationsEnabled: boolean;
   verificationsDisabledMessage: string;
   photoInstructions: string;
+  photoInstructionsEs: string;
+  photoInstructionsFr: string;
+  photoInstructionsDefaultLanguage: string;
   showPhotoInstructionsBeforeSubmit: boolean;
   pendingTurnaroundDays: number;
   denyReasons: PublicDenyReasonConfig[];
@@ -913,6 +922,9 @@ const CONFIG_FIELD = {
   verificationsEnabled: 'verifications_enabled',
   requiredPhotoCount: 'required_photo_count',
   photoInstructions: 'photo_instructions',
+  photoInstructionsEs: 'photo_instructions_es',
+  photoInstructionsFr: 'photo_instructions_fr',
+  photoInstructionsDefaultLanguage: 'photo_instructions_default_language',
   pendingTurnaroundDays: 'pending_turnaround_days',
   modmailSubject: 'modmail_subject',
   pendingBody: 'pending_body',
@@ -1086,6 +1098,9 @@ function toPublicHubConfig(config: RuntimeConfig): PublicHubConfig {
     verificationsEnabled: config.verificationsEnabled,
     verificationsDisabledMessage: config.verificationsDisabledMessage,
     photoInstructions: config.photoInstructions,
+    photoInstructionsEs: config.photoInstructionsEs,
+    photoInstructionsFr: config.photoInstructionsFr,
+    photoInstructionsDefaultLanguage: config.photoInstructionsDefaultLanguage,
     showPhotoInstructionsBeforeSubmit: config.showPhotoInstructionsBeforeSubmit,
     pendingTurnaroundDays: config.pendingTurnaroundDays,
     denyReasons: config.denyReasons.map((reason) => ({
@@ -6474,6 +6489,14 @@ async function onSaveFlairTemplateValues(
     values.requiredPhotoCount === undefined
       ? existingConfig.requiredPhotoCount
       : parseRequiredPhotoCount(values.requiredPhotoCount, existingConfig.requiredPhotoCount);
+  const photoInstructions = values.photoInstructions?.trim() ?? '';
+  const photoInstructionsEs =
+    values.photoInstructionsEs === undefined ? existingConfig.photoInstructionsEs : values.photoInstructionsEs.trim();
+  const photoInstructionsFr =
+    values.photoInstructionsFr === undefined ? existingConfig.photoInstructionsFr : values.photoInstructionsFr.trim();
+  const photoInstructionsDefaultLanguage = normalizePhotoInstructionLanguage(
+    values.photoInstructionsDefaultLanguage ?? existingConfig.photoInstructionsDefaultLanguage
+  );
   const flairTemplateId = values.flairTemplateId?.trim() ?? '';
   const flairTemplateValidation = validateFlairTemplateId(flairTemplateId);
   if (!flairTemplateValidation.isValid) {
@@ -6528,7 +6551,10 @@ async function onSaveFlairTemplateValues(
       ? {}
       : { [CONFIG_FIELD.verificationsEnabled]: `${values.verificationsEnabled !== false}` }),
     [CONFIG_FIELD.requiredPhotoCount]: `${requiredPhotoCount}`,
-    [CONFIG_FIELD.photoInstructions]: values.photoInstructions?.trim() ?? '',
+    [CONFIG_FIELD.photoInstructions]: photoInstructions,
+    [CONFIG_FIELD.photoInstructionsEs]: photoInstructionsEs,
+    [CONFIG_FIELD.photoInstructionsFr]: photoInstructionsFr,
+    [CONFIG_FIELD.photoInstructionsDefaultLanguage]: photoInstructionsDefaultLanguage,
     [CONFIG_FIELD.flairTemplateId]: flairTemplateId,
     [CONFIG_FIELD.flairCssClass]: values.flairCssClass?.trim() ?? '',
     [CONFIG_FIELD.additionalApprovalFlairs]: serializeAdditionalApprovalFlairs(normalizedAdditional),
@@ -6539,7 +6565,10 @@ async function onSaveFlairTemplateValues(
     ...existingConfig,
     verificationsEnabled: values.verificationsEnabled === undefined ? existingConfig.verificationsEnabled : values.verificationsEnabled !== false,
     requiredPhotoCount,
-    photoInstructions: values.photoInstructions?.trim() ?? '',
+    photoInstructions,
+    photoInstructionsEs,
+    photoInstructionsFr,
+    photoInstructionsDefaultLanguage,
     flairTemplateId,
     flairCssClass: values.flairCssClass?.trim() ?? '',
     additionalApprovalFlairs: normalizedAdditional,
@@ -6691,6 +6720,11 @@ async function getRuntimeConfig(context: Devvit.Context, subredditId: string): P
     typeof rawShowPhotoInstructionsBeforeSubmit === 'boolean'
       ? rawShowPhotoInstructionsBeforeSubmit
       : parseBooleanString(rawShowPhotoInstructionsBeforeSubmit, false);
+  const photoInstructionsEs = normalizeOptionalSettingText(stored[CONFIG_FIELD.photoInstructionsEs]);
+  const photoInstructionsFr = normalizeOptionalSettingText(stored[CONFIG_FIELD.photoInstructionsFr]);
+  const photoInstructionsDefaultLanguage = normalizePhotoInstructionLanguage(
+    stored[CONFIG_FIELD.photoInstructionsDefaultLanguage]
+  );
   const pendingTurnaroundRaw = firstNonEmpty(stored[CONFIG_FIELD.pendingTurnaroundDays]);
   const pendingTurnaroundDays = parsePositiveInt(pendingTurnaroundRaw, DEFAULT_PENDING_TURNAROUND_DAYS);
   const approveBodyRaw = firstNonEmpty(stored[CONFIG_FIELD.approveBody]) ?? DEFAULT_APPROVE_BODY;
@@ -6713,7 +6747,10 @@ async function getRuntimeConfig(context: Devvit.Context, subredditId: string): P
     autoFlairReconcileEnabled,
     maxDenialsBeforeBlock,
     requiredPhotoCount,
-    photoInstructions: stored[CONFIG_FIELD.photoInstructions] ?? '',
+    photoInstructions: normalizeOptionalSettingText(stored[CONFIG_FIELD.photoInstructions]),
+    photoInstructionsEs,
+    photoInstructionsFr,
+    photoInstructionsDefaultLanguage,
     showPhotoInstructionsBeforeSubmit,
     denyReasons,
     pendingTurnaroundDays: pendingTurnaroundDays ?? DEFAULT_PENDING_TURNAROUND_DAYS,
@@ -8192,6 +8229,17 @@ function normalizeInstallSettingMessage(
   return normalized || fallback;
 }
 
+function normalizeOptionalSettingText(value: string | undefined | null): string {
+  return String(value ?? '').trim();
+}
+
+function normalizePhotoInstructionLanguage(value: string | undefined | null): string {
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase();
+  return normalized === 'es' || normalized === 'fr' ? normalized : 'en';
+}
+
 function formatPendingTurnaroundDays(days: number): string {
   const normalizedDays = Number.isFinite(days) ? Math.max(0, Math.trunc(days)) : 0;
   return `${normalizedDays} ${normalizedDays === 1 ? 'day' : 'days'}`;
@@ -8741,6 +8789,7 @@ export {
   loadHubDashboard,
   loadModDashboard,
   getHubModeratorUiState,
+  getRuntimeConfig,
   cachePositiveModeratorUiState,
   searchHistoryRecords,
   searchApprovedRecords,

--- a/webroot/hub-app.js
+++ b/webroot/hub-app.js
@@ -37,6 +37,25 @@ const SUBMIT_ACKNOWLEDGEMENTS = [
 ];
 const MANUAL_SOURCE_MARKERS = ['css-substring-match', 'css-wildcard-match'];
 const WORKTREE_LABEL = typeof __VOUCHX_WORKTREE_LABEL__ === 'string' ? __VOUCHX_WORKTREE_LABEL__.trim() : '';
+const PHOTO_INSTRUCTION_LANGUAGE_OPTIONS = Object.freeze([
+  { id: 'en', label: 'en', configField: 'photoInstructions' },
+  { id: 'es', label: 'es', configField: 'photoInstructionsEs' },
+  { id: 'fr', label: 'fr', configField: 'photoInstructionsFr' },
+]);
+const PHOTO_INSTRUCTION_LANGUAGE_COPY = Object.freeze({
+  en: {
+    title: 'Photo Requirements',
+    subtitle: 'Review these instructions carefully before submitting your photos.',
+  },
+  es: {
+    title: 'Requisitos para las fotos',
+    subtitle: 'Lea atentamente estas instrucciones antes de enviar sus fotos.',
+  },
+  fr: {
+    title: 'Exigences relatives aux photos',
+    subtitle: 'Veuillez lire attentivement ces instructions avant de soumettre vos photos.',
+  },
+});
 
 function createShell(root, inline) {
   root.innerHTML = `
@@ -115,10 +134,16 @@ function createShell(root, inline) {
 
       <div data-el="photo-instructions-modal" class="hub-modal hidden">
         <div class="hub-modal-card">
-          <h2>Photo Requirements</h2>
-          <p class="meta">
+          <h2 data-el="photo-instructions-title">Photo Requirements</h2>
+          <p data-el="photo-instructions-subtitle" class="meta">
             Review these instructions carefully before submitting your photos.
           </p>
+          <div
+            data-el="photo-instructions-language-toggle"
+            class="hub-language-switcher hidden"
+            role="group"
+            aria-label="Instruction language"
+          ></div>
           <div data-el="photo-instructions-scroll-shell" class="hub-scroll-shell" data-scroll-overflow="false" data-scroll-bottom="true">
             <div data-el="photo-instructions-body" class="markdown-body hub-modal-copy"></div>
             <div data-el="photo-instructions-scroll-hint" class="hub-scroll-hint hidden" aria-hidden="true">Scroll Down ↓</div>
@@ -152,6 +177,9 @@ function createShell(root, inline) {
     submitWarningCancel: root.querySelector('[data-el="submit-warning-cancel"]'),
     submitWarningContinue: root.querySelector('[data-el="submit-warning-continue"]'),
     photoInstructionsModal: root.querySelector('[data-el="photo-instructions-modal"]'),
+    photoInstructionsTitle: root.querySelector('[data-el="photo-instructions-title"]'),
+    photoInstructionsSubtitle: root.querySelector('[data-el="photo-instructions-subtitle"]'),
+    photoInstructionsLanguageToggle: root.querySelector('[data-el="photo-instructions-language-toggle"]'),
     photoInstructionsScrollShell: root.querySelector('[data-el="photo-instructions-scroll-shell"]'),
     photoInstructionsBody: root.querySelector('[data-el="photo-instructions-body"]'),
     photoInstructionsScrollHint: root.querySelector('[data-el="photo-instructions-scroll-hint"]'),
@@ -434,6 +462,42 @@ function renderInstructionTemplate(value, state) {
       .replace(/\s+/g, '_');
     return replacements[normalizedKey] ?? '';
   });
+}
+
+function getPhotoInstructionContent(config, language) {
+  const option = PHOTO_INSTRUCTION_LANGUAGE_OPTIONS.find((item) => item.id === language);
+  if (!option) {
+    return '';
+  }
+  return String(config?.[option.configField] || '').trim();
+}
+
+function getAvailablePhotoInstructionLanguages(state) {
+  return PHOTO_INSTRUCTION_LANGUAGE_OPTIONS.filter((option) =>
+    Boolean(getPhotoInstructionContent(state?.config, option.id))
+  );
+}
+
+function getDefaultPhotoInstructionLanguage(state) {
+  const availableLanguages = getAvailablePhotoInstructionLanguages(state);
+  const configuredDefaultLanguage = String(state?.config?.photoInstructionsDefaultLanguage || 'en')
+    .trim()
+    .toLowerCase();
+  if (availableLanguages.some((option) => option.id === configuredDefaultLanguage)) {
+    return configuredDefaultLanguage;
+  }
+  if (availableLanguages.some((option) => option.id === 'en')) {
+    return 'en';
+  }
+  return availableLanguages[0]?.id || 'en';
+}
+
+function getPhotoInstructionHeading(language) {
+  return PHOTO_INSTRUCTION_LANGUAGE_COPY[language] || PHOTO_INSTRUCTION_LANGUAGE_COPY.en;
+}
+
+function hasAnyConfiguredPhotoInstructions(config) {
+  return PHOTO_INSTRUCTION_LANGUAGE_OPTIONS.some((option) => Boolean(getPhotoInstructionContent(config, option.id)));
 }
 
 function buildStatusTooltipHtml(content) {
@@ -739,6 +803,42 @@ export function mountHub(options = {}) {
     }
   }
 
+  function renderPhotoInstructionsLanguageSwitcher(availableLanguages, activeLanguage, onSelect) {
+    if (!refs.photoInstructionsLanguageToggle) {
+      return;
+    }
+    refs.photoInstructionsLanguageToggle.innerHTML = '';
+    refs.photoInstructionsLanguageToggle.classList.toggle('hidden', availableLanguages.length <= 1);
+    if (availableLanguages.length <= 1) {
+      return;
+    }
+
+    for (const [index, option] of availableLanguages.entries()) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'hub-language-switcher-btn';
+      button.textContent = option.label;
+      button.setAttribute('aria-pressed', option.id === activeLanguage ? 'true' : 'false');
+      if (option.id === activeLanguage) {
+        button.classList.add('is-active');
+      }
+      button.addEventListener('click', () => {
+        if (option.id !== activeLanguage) {
+          onSelect(option.id);
+        }
+      });
+      refs.photoInstructionsLanguageToggle.appendChild(button);
+
+      if (index < availableLanguages.length - 1) {
+        const separator = document.createElement('span');
+        separator.className = 'hub-language-switcher-separator';
+        separator.setAttribute('aria-hidden', 'true');
+        separator.textContent = '|';
+        refs.photoInstructionsLanguageToggle.appendChild(separator);
+      }
+    }
+  }
+
   if (refs.photoInstructionsBody) {
     refs.photoInstructionsBody.addEventListener('scroll', () => {
       updatePhotoInstructionsScrollAffordance();
@@ -952,7 +1052,7 @@ export function mountHub(options = {}) {
       return;
     }
     const shouldShowPhotoInstructionsFirst = Boolean(
-      hubState?.config?.showPhotoInstructionsBeforeSubmit && String(hubState?.config?.photoInstructions || '').trim()
+      hubState?.config?.showPhotoInstructionsBeforeSubmit && hasAnyConfiguredPhotoInstructions(hubState?.config)
     );
     if (shouldShowPhotoInstructionsFirst) {
       if (shouldUseAndroidPhotoInstructionsStep() && !photoInstructionsOnly) {
@@ -1069,11 +1169,30 @@ export function mountHub(options = {}) {
         return;
       }
 
-      refs.photoInstructionsBody.innerHTML = renderMarkdown(
-        renderInstructionTemplate(hubState?.config?.photoInstructions || '', hubState)
-      );
-      refs.photoInstructionsBody.scrollTop = 0;
-      refs.photoInstructionsModal.scrollTop = 0;
+      const availableLanguages = getAvailablePhotoInstructionLanguages(hubState);
+      let selectedLanguage = getDefaultPhotoInstructionLanguage(hubState);
+      const renderPhotoInstructionsContent = () => {
+        const source = getPhotoInstructionContent(hubState?.config, selectedLanguage);
+        const heading = getPhotoInstructionHeading(selectedLanguage);
+        if (refs.photoInstructionsTitle) {
+          refs.photoInstructionsTitle.textContent = heading.title;
+        }
+        if (refs.photoInstructionsSubtitle) {
+          refs.photoInstructionsSubtitle.textContent = heading.subtitle;
+        }
+        refs.photoInstructionsBody.innerHTML = renderMarkdown(renderInstructionTemplate(source, hubState));
+        refs.photoInstructionsBody.scrollTop = 0;
+        refs.photoInstructionsModal.scrollTop = 0;
+        renderPhotoInstructionsLanguageSwitcher(availableLanguages, selectedLanguage, (nextLanguage) => {
+          selectedLanguage = nextLanguage;
+          renderPhotoInstructionsContent();
+          window.requestAnimationFrame(() => {
+            updatePhotoInstructionsScrollAffordance();
+          });
+        });
+      };
+
+      renderPhotoInstructionsContent();
       const hideCloseButton = dedicatedView && requireContinue;
       refs.photoInstructionsContinue.classList.toggle('hidden', !requireContinue);
       refs.photoInstructionsClose.classList.toggle('hidden', hideCloseButton);
@@ -1108,6 +1227,10 @@ export function mountHub(options = {}) {
         refs.photoInstructionsContinue.classList.add('hidden');
         refs.photoInstructionsClose.classList.remove('hidden');
         refs.photoInstructionsClose.textContent = 'Close';
+        if (refs.photoInstructionsLanguageToggle) {
+          refs.photoInstructionsLanguageToggle.innerHTML = '';
+          refs.photoInstructionsLanguageToggle.classList.add('hidden');
+        }
         if (dedicatedView) {
           window.location.replace(buildInternalNavigationUrl('./hub.html'));
         }

--- a/webroot/hub-app.js
+++ b/webroot/hub-app.js
@@ -46,14 +46,17 @@ const PHOTO_INSTRUCTION_LANGUAGE_COPY = Object.freeze({
   en: {
     title: 'Photo Requirements',
     subtitle: 'Review these instructions carefully before submitting your photos.',
+    scrollHint: 'Scroll Down ↓',
   },
   es: {
     title: 'Requisitos para las fotos',
     subtitle: 'Lea atentamente estas instrucciones antes de enviar sus fotos.',
+    scrollHint: 'Desplázate hacia abajo ↓',
   },
   fr: {
     title: 'Exigences relatives aux photos',
     subtitle: 'Veuillez lire attentivement ces instructions avant de soumettre vos photos.',
+    scrollHint: 'Défilez vers le bas ↓',
   },
 });
 
@@ -1179,6 +1182,9 @@ export function mountHub(options = {}) {
         }
         if (refs.photoInstructionsSubtitle) {
           refs.photoInstructionsSubtitle.textContent = heading.subtitle;
+        }
+        if (refs.photoInstructionsScrollHint) {
+          refs.photoInstructionsScrollHint.textContent = heading.scrollHint;
         }
         refs.photoInstructionsBody.innerHTML = renderMarkdown(renderInstructionTemplate(source, hubState));
         refs.photoInstructionsBody.scrollTop = 0;

--- a/webroot/hub-ui.css
+++ b/webroot/hub-ui.css
@@ -660,6 +660,42 @@ button:not(:disabled):hover {
   margin-top: 16px;
 }
 
+.hub-language-switcher {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1;
+}
+
+.hub-language-switcher-btn {
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.hub-language-switcher-btn:hover,
+.hub-language-switcher-btn:focus-visible {
+  color: var(--accent);
+}
+
+.hub-language-switcher-btn.is-active {
+  color: var(--text);
+}
+
+.hub-language-switcher-separator {
+  color: color-mix(in srgb, var(--muted) 76%, transparent);
+}
+
 .hub-scroll-shell::before,
 .hub-scroll-shell::after {
   content: "";

--- a/webroot/mod-panel.css
+++ b/webroot/mod-panel.css
@@ -82,6 +82,7 @@ h3,
 h4,
 .tab-btn,
 .settings-tab-btn,
+.settings-language-tab-btn,
 .theme-card-title {
   font-family: var(--font-display);
 }
@@ -279,6 +280,47 @@ textarea {
   color: var(--text);
   background: color-mix(in srgb, var(--panel-surface-strong) 86%, var(--primary-soft) 14%);
   border-bottom-color: color-mix(in srgb, var(--primary) 72%, white 28%);
+}
+
+.settings-language-tabs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 14px 0 18px;
+}
+
+.settings-language-tab-btn {
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--panel-border) 74%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-surface-soft) 90%, black 10%);
+  color: var(--muted);
+  cursor: pointer;
+  min-height: 34px;
+  padding: 7px 12px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.settings-language-tab-btn:hover {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--panel-border-strong) 58%, transparent);
+}
+
+.settings-language-tab-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 18%, transparent);
+}
+
+.settings-language-tab-btn-active {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--primary) 42%, var(--panel-border) 58%);
+  background: color-mix(in srgb, var(--panel-surface-strong) 82%, var(--primary-soft) 18%);
 }
 
 #main-content {
@@ -530,6 +572,11 @@ textarea {
 .settings-panel {
   display: grid;
   gap: 18px;
+}
+
+.settings-language-panel {
+  display: grid;
+  gap: 8px;
 }
 
 .template-settings-grid,

--- a/webroot/mod-panel.css
+++ b/webroot/mod-panel.css
@@ -272,8 +272,78 @@ textarea {
   flex-wrap: wrap;
   gap: 6px 10px;
   padding: 0 0 12px;
-  margin: 0 0 18px;
+  margin: 0;
   border-bottom: 1px solid color-mix(in srgb, var(--panel-divider) 88%, transparent);
+}
+
+.settings-tabs-shell {
+  position: relative;
+  margin: 0 0 18px;
+}
+
+.settings-tabs-shell::before,
+.settings-tabs-shell::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 10px;
+  width: 34px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 160ms ease;
+  z-index: 1;
+}
+
+.settings-tabs-shell::before {
+  left: 0;
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--panel-bg) 100%, transparent) 0%,
+      color-mix(in srgb, var(--panel-bg) 88%, transparent) 52%,
+      color-mix(in srgb, var(--panel-bg) 0%, transparent) 100%
+    );
+}
+
+.settings-tabs-shell::after {
+  right: 0;
+  background:
+    linear-gradient(
+      270deg,
+      color-mix(in srgb, var(--panel-bg) 100%, transparent) 0%,
+      color-mix(in srgb, var(--panel-bg) 88%, transparent) 52%,
+      color-mix(in srgb, var(--panel-bg) 0%, transparent) 100%
+    );
+}
+
+.settings-tabs-shell[data-scroll-left="true"]::before {
+  opacity: 1;
+}
+
+.settings-tabs-shell[data-scroll-right="true"]::after {
+  opacity: 1;
+}
+
+.settings-tabs-scroll-hint {
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
+  z-index: 2;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--primary) 36%, var(--panel-border) 64%);
+  background: color-mix(in srgb, var(--panel-surface-strong) 86%, var(--primary-soft) 14%);
+  color: color-mix(in srgb, var(--primary) 74%, var(--text) 26%);
+  font-size: 0.88rem;
+  font-weight: 800;
+  line-height: 1;
+  pointer-events: none;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.16);
 }
 
 .settings-tab-btn-active {
@@ -577,6 +647,28 @@ textarea {
 .settings-language-panel {
   display: grid;
   gap: 8px;
+}
+
+.instructions-settings-card {
+  display: grid;
+  gap: 18px;
+}
+
+.instructions-settings-note {
+  margin-top: 6px;
+  margin-bottom: 2px;
+}
+
+.instructions-default-language-block {
+  margin-top: 14px;
+}
+
+.instructions-default-language-block .field-help {
+  margin-top: 10px;
+}
+
+.instructions-formatting-help-row {
+  margin-top: 16px;
 }
 
 .template-settings-grid,
@@ -2177,6 +2269,10 @@ textarea {
     overflow-x: auto;
     gap: 6px;
     padding-bottom: 8px;
+    margin-bottom: 0;
+  }
+
+  .settings-tabs-shell {
     margin-bottom: 16px;
   }
 
@@ -2284,6 +2380,19 @@ textarea {
 }
 
 @media (max-width: 560px) {
+  .settings-tabs-shell::before,
+  .settings-tabs-shell::after {
+    width: 28px;
+  }
+
+  .settings-tabs-scroll-hint {
+    right: 8px;
+    bottom: 6px;
+    width: 24px;
+    height: 24px;
+    font-size: 0.82rem;
+  }
+
   .queue-section-head {
     gap: 8px;
   }

--- a/webroot/mod-panel.html
+++ b/webroot/mod-panel.html
@@ -320,11 +320,12 @@
           <div class="section-head">
             <div>
               <h2>Settings</h2>
-              <p class="section-copy muted">Configure verification workflow, modmail templates, and the user-facing theme.</p>
+              <p class="section-copy muted">Configure verification workflow, localized photo instructions, modmail templates, and the user-facing theme.</p>
             </div>
           </div>
           <nav class="settings-tabs" aria-label="Settings sections">
             <button class="settings-tab-btn settings-tab-btn-active" data-settings-tab="general">General</button>
+            <button class="settings-tab-btn" data-settings-tab="instructions">Instructions</button>
             <button class="settings-tab-btn" data-settings-tab="templates">Templates</button>
             <button class="settings-tab-btn" data-settings-tab="themes">Themes</button>
           </nav>
@@ -442,29 +443,6 @@
                   </div>
                 </div>
                 <p class="muted small field-help">Controls how many upload fields users see in the submit form.</p>
-
-                <label class="minor-heading field-subsection-heading" for="photo-instructions">Photo instructions</label>
-                <div class="field-label-row">
-                  <label class="field-label" for="photo-instructions">Instructions shown when user presses Photo Requirements</label>
-                  <details class="team-stats-help">
-                    <summary class="team-stats-help-button" aria-label="Explain Markdown formatting">?</summary>
-                    <div class="team-stats-help-tooltip" role="note">
-                      <p><strong>Markdown and placeholders</strong></p>
-                      <p><strong>Bold:</strong> <code>**text**</code></p>
-                      <p><em>Italic:</em> <code>*text*</code></p>
-                      <p><strong>Link:</strong> <code>[text](https://example.com)</code></p>
-                      <p><strong>Inline code:</strong> <code>`text`</code></p>
-                      <p><strong>Heading:</strong> <code>## Heading</code></p>
-                      <p><strong>Line break:</strong> press Enter twice</p>
-                      <p><strong>Bullet list:</strong><br><code>- Item</code><br><code>- Item</code></p>
-                      <p><strong>Numbered list:</strong><br><code>1. Item</code><br><code>2. Item</code></p>
-                      <p><strong>Placeholders:</strong> <code>{{subreddit}}</code>, <code>{{days}}</code></p>
-                      <p><code>{{days}}</code> already includes the unit, for example <code>3 days</code>.</p>
-                      <p>What you type is what users will see in the Photo Requirements popup.</p>
-                    </div>
-                  </details>
-                </div>
-                <textarea id="photo-instructions" class="field-textarea" rows="8"></textarea>
               </div>
 
               <div class="row section-actions">
@@ -474,6 +452,86 @@
                 Install settings for this subreddit are available here:
                 <a id="install-settings-link" href="#" target="_blank" rel="noopener noreferrer">Open install settings</a>
               </p>
+            </div>
+          </div>
+
+          <div id="settings-panel-instructions" class="settings-panel hidden">
+            <div class="content-card">
+              <div class="card-head">
+                <div>
+                  <h3 class="section-heading">Photo instructions</h3>
+                  <p class="section-copy muted small">
+                    These instructions only affect the user-facing Photo Requirements view. You can add Spanish or French versions and choose which language opens first.
+                  </p>
+                </div>
+              </div>
+
+              <p class="muted small field-help">
+                We recommend using
+                <a href="https://translate.google.com/" target="_blank" rel="noopener noreferrer">Google Translate</a>
+                to help provide instructions in multiple languages for non-native speakers.
+              </p>
+
+              <div class="field-stack">
+                <label class="field-label" for="photo-instructions-default-language">Default instruction language</label>
+                <select id="photo-instructions-default-language" class="field-select">
+                  <option value="en">English</option>
+                  <option value="es">Spanish</option>
+                  <option value="fr">French</option>
+                </select>
+                <p class="muted small field-help">If the selected language is empty, VouchX falls back to the next available instruction language.</p>
+              </div>
+
+              <div class="field-label-row">
+                <p class="field-label">Formatting help</p>
+                <details class="team-stats-help">
+                  <summary class="team-stats-help-button" aria-label="Explain markdown and placeholders">?</summary>
+                  <div class="team-stats-help-tooltip" role="note">
+                    <p><strong>Markdown and placeholders</strong></p>
+                    <p><strong>Bold:</strong> <code>**text**</code></p>
+                    <p><em>Italic:</em> <code>*text*</code></p>
+                    <p><strong>Link:</strong> <code>[text](https://example.com)</code></p>
+                    <p><strong>Inline code:</strong> <code>`text`</code></p>
+                    <p><strong>Heading:</strong> <code>## Heading</code></p>
+                    <p><strong>Line break:</strong> press Enter twice</p>
+                    <p><strong>Bullet list:</strong><br><code>- Item</code><br><code>- Item</code></p>
+                    <p><strong>Numbered list:</strong><br><code>1. Item</code><br><code>2. Item</code></p>
+                    <p><strong>Placeholders:</strong> <code>{{subreddit}}</code>, <code>{{days}}</code></p>
+                    <p><code>{{days}}</code> already includes the unit, for example <code>3 days</code>.</p>
+                    <p>What you type is what users will see in the Photo Requirements popup or Android instructions page.</p>
+                  </div>
+                </details>
+              </div>
+
+              <nav class="settings-language-tabs" aria-label="Instruction languages">
+                <button class="settings-language-tab-btn settings-language-tab-btn-active" data-instruction-language="en" type="button">English</button>
+                <button class="settings-language-tab-btn" data-instruction-language="es" type="button">Spanish</button>
+                <button class="settings-language-tab-btn" data-instruction-language="fr" type="button">French</button>
+              </nav>
+
+              <div id="instruction-language-panel-en" class="settings-language-panel">
+                <label class="field-label" for="photo-instructions">English instructions</label>
+                <p class="muted small field-help">Used when the default language is English, and also as a fallback when other languages are unavailable.</p>
+                <textarea id="photo-instructions" class="field-textarea" rows="10"></textarea>
+              </div>
+
+              <div id="instruction-language-panel-es" class="settings-language-panel hidden">
+                <label class="field-label" for="photo-instructions-es">Spanish instructions</label>
+                <p class="muted small field-help">Adds `es` to the in-view language switcher when this field has content, and can be used as the default opening language.</p>
+                <textarea id="photo-instructions-es" class="field-textarea" rows="10"></textarea>
+              </div>
+
+              <div id="instruction-language-panel-fr" class="settings-language-panel hidden">
+                <label class="field-label" for="photo-instructions-fr">French instructions</label>
+                <p class="muted small field-help">Adds `fr` to the in-view language switcher when this field has content, and can be used as the default opening language.</p>
+                <textarea id="photo-instructions-fr" class="field-textarea" rows="10"></textarea>
+              </div>
+            </div>
+
+            <div class="panel-footer">
+              <div class="row section-actions section-actions-inline">
+                <button id="save-instructions-btn" class="btn btn-primary">Save instructions</button>
+              </div>
             </div>
           </div>
 

--- a/webroot/mod-panel.html
+++ b/webroot/mod-panel.html
@@ -323,12 +323,20 @@
               <p class="section-copy muted">Configure verification workflow, localized photo instructions, modmail templates, and the user-facing theme.</p>
             </div>
           </div>
-          <nav class="settings-tabs" aria-label="Settings sections">
-            <button class="settings-tab-btn settings-tab-btn-active" data-settings-tab="general">General</button>
-            <button class="settings-tab-btn" data-settings-tab="instructions">Instructions</button>
-            <button class="settings-tab-btn" data-settings-tab="templates">Templates</button>
-            <button class="settings-tab-btn" data-settings-tab="themes">Themes</button>
-          </nav>
+          <div
+            id="settings-tabs-shell"
+            class="settings-tabs-shell"
+            data-scroll-left="false"
+            data-scroll-right="false"
+          >
+            <nav id="settings-tabs" class="settings-tabs" aria-label="Settings sections">
+              <button class="settings-tab-btn settings-tab-btn-active" data-settings-tab="general">General</button>
+              <button class="settings-tab-btn" data-settings-tab="instructions">Photo Instructions</button>
+              <button class="settings-tab-btn" data-settings-tab="templates">Templates</button>
+              <button class="settings-tab-btn" data-settings-tab="themes">Themes</button>
+            </nav>
+            <div id="settings-tabs-scroll-hint" class="settings-tabs-scroll-hint hidden" aria-hidden="true">&rarr;</div>
+          </div>
 
           <div id="settings-panel-general" class="settings-panel">
             <div class="settings-grid">
@@ -456,23 +464,23 @@
           </div>
 
           <div id="settings-panel-instructions" class="settings-panel hidden">
-            <div class="content-card">
+            <div class="content-card instructions-settings-card">
               <div class="card-head">
                 <div>
-                  <h3 class="section-heading">Photo instructions</h3>
+                  <h3 class="section-heading">Photo Instructions</h3>
                   <p class="section-copy muted small">
                     These instructions only affect the user-facing Photo Requirements view. You can add Spanish or French versions and choose which language opens first.
                   </p>
                 </div>
               </div>
 
-              <p class="muted small field-help">
+              <p class="instructions-settings-note muted small">
                 We recommend using
                 <a href="https://translate.google.com/" target="_blank" rel="noopener noreferrer">Google Translate</a>
                 to help provide instructions in multiple languages for non-native speakers.
               </p>
 
-              <div class="field-stack">
+              <div class="field-stack instructions-default-language-block">
                 <label class="field-label" for="photo-instructions-default-language">Default instruction language</label>
                 <select id="photo-instructions-default-language" class="field-select">
                   <option value="en">English</option>
@@ -482,7 +490,7 @@
                 <p class="muted small field-help">If the selected language is empty, VouchX falls back to the next available instruction language.</p>
               </div>
 
-              <div class="field-label-row">
+              <div class="field-label-row instructions-formatting-help-row">
                 <p class="field-label">Formatting help</p>
                 <details class="team-stats-help">
                   <summary class="team-stats-help-button" aria-label="Explain markdown and placeholders">?</summary>

--- a/webroot/mod-panel.js
+++ b/webroot/mod-panel.js
@@ -18,6 +18,7 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   const settingsTabButtons = Array.from(document.querySelectorAll('.settings-tab-btn'));
   const settingsPanels = {
     general: document.getElementById('settings-panel-general'),
+    instructions: document.getElementById('settings-panel-instructions'),
     templates: document.getElementById('settings-panel-templates'),
     themes: document.getElementById('settings-panel-themes'),
   };
@@ -98,6 +99,7 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   const refreshBtn = document.getElementById('refresh-btn');
   const blockUserBtn = document.getElementById('block-user-btn');
   const saveFlairBtn = document.getElementById('save-flair-btn');
+  const saveInstructionsBtn = document.getElementById('save-instructions-btn');
   const saveTemplatesBtn = document.getElementById('save-templates-btn');
   const saveThemeBtn = document.getElementById('save-theme-btn');
   const resetThemeBtn = document.getElementById('reset-theme-btn');
@@ -124,7 +126,16 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   const installSettingsRow = document.getElementById('install-settings-row');
   const installSettingsLink = document.getElementById('install-settings-link');
   const requiredPhotoCountInput = document.getElementById('required-photo-count');
+  const photoInstructionsDefaultLanguageInput = document.getElementById('photo-instructions-default-language');
   const photoInstructionsInput = document.getElementById('photo-instructions');
+  const photoInstructionsEsInput = document.getElementById('photo-instructions-es');
+  const photoInstructionsFrInput = document.getElementById('photo-instructions-fr');
+  const instructionLanguageTabButtons = Array.from(document.querySelectorAll('.settings-language-tab-btn'));
+  const instructionLanguagePanels = {
+    en: document.getElementById('instruction-language-panel-en'),
+    es: document.getElementById('instruction-language-panel-es'),
+    fr: document.getElementById('instruction-language-panel-fr'),
+  };
 
   const pendingTurnaroundDaysInput = document.getElementById('pending-turnaround-days');
   const modmailSubjectInput = document.getElementById('modmail-subject');
@@ -205,6 +216,7 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   let activePrimaryTab = 'pending';
   let activeHistoryView = 'records';
   let activeSettingsTab = 'general';
+  let activeInstructionLanguage = 'en';
   let activeStatsRange = 'weekly';
   let selectedThemePreset = 'coastal_light';
   let lastStateUpdatedAt = 0;
@@ -1188,7 +1200,12 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
           flairCssClass: flairCssClassInput ? flairCssClassInput.value : '',
           additionalApprovalFlairs,
           requiredPhotoCount: requiredPhotoCountInput ? Number(requiredPhotoCountInput.value || 2) : 2,
+          photoInstructionsDefaultLanguage: photoInstructionsDefaultLanguageInput
+            ? photoInstructionsDefaultLanguageInput.value
+            : 'en',
           photoInstructions: photoInstructionsInput ? photoInstructionsInput.value : '',
+          photoInstructionsEs: photoInstructionsEsInput ? photoInstructionsEsInput.value : '',
+          photoInstructionsFr: photoInstructionsFrInput ? photoInstructionsFrInput.value : '',
         };
         const savedVerificationsEnabled = state ? state.config.verificationsEnabled !== false : true;
         if (verificationsEnabledInput && Boolean(verificationsEnabledInput.checked) !== savedVerificationsEnabled) {
@@ -1268,7 +1285,10 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       additionalApprovalFlairThird: stringInputValue(approvalFlairThirdSelect),
       verificationsEnabled: boolInputValue(verificationsEnabledInput),
       requiredPhotoCount: stringInputValue(requiredPhotoCountInput),
+      photoInstructionsDefaultLanguage: stringInputValue(photoInstructionsDefaultLanguageInput) || 'en',
       photoInstructions: stringInputValue(photoInstructionsInput),
+      photoInstructionsEs: stringInputValue(photoInstructionsEsInput),
+      photoInstructionsFr: stringInputValue(photoInstructionsFrInput),
     };
     const savedRequiredPhotoCount = `${Number(state.config.requiredPhotoCount || 2)}`;
     const dirty =
@@ -1277,10 +1297,13 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       normalizeTemplateIdValue(draft.additionalApprovalFlairSecond) !==
         normalizeTemplateIdValue(state.config.additionalApprovalFlairs?.[0]?.templateId || '') ||
       normalizeTemplateIdValue(draft.additionalApprovalFlairThird) !==
-        normalizeTemplateIdValue(state.config.additionalApprovalFlairs?.[1]?.templateId || '') ||
+      normalizeTemplateIdValue(state.config.additionalApprovalFlairs?.[1]?.templateId || '') ||
       draft.verificationsEnabled !== (state.config.verificationsEnabled !== false) ||
       draft.requiredPhotoCount !== savedRequiredPhotoCount ||
-      draft.photoInstructions !== String(state.config.photoInstructions || '');
+      draft.photoInstructionsDefaultLanguage !== String(state.config.photoInstructionsDefaultLanguage || 'en') ||
+      draft.photoInstructions !== String(state.config.photoInstructions || '') ||
+      draft.photoInstructionsEs !== String(state.config.photoInstructionsEs || '') ||
+      draft.photoInstructionsFr !== String(state.config.photoInstructionsFr || '');
     return dirty ? draft : null;
   }
 
@@ -1407,12 +1430,22 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     if (requiredPhotoCountInput) {
       requiredPhotoCountInput.value = draft.requiredPhotoCount;
     }
+    if (photoInstructionsDefaultLanguageInput) {
+      photoInstructionsDefaultLanguageInput.value = draft.photoInstructionsDefaultLanguage || 'en';
+    }
     if (photoInstructionsInput) {
       photoInstructionsInput.value = draft.photoInstructions;
+    }
+    if (photoInstructionsEsInput) {
+      photoInstructionsEsInput.value = draft.photoInstructionsEs || '';
+    }
+    if (photoInstructionsFrInput) {
+      photoInstructionsFrInput.value = draft.photoInstructionsFr || '';
     }
     additionalApprovalFlairSecondDraft = normalizeTemplateIdValue(draft.additionalApprovalFlairSecond || '');
     additionalApprovalFlairThirdDraft = normalizeTemplateIdValue(draft.additionalApprovalFlairThird || '');
     renderApprovalFlairPicker();
+    setInstructionsLanguage(activeInstructionLanguage);
   }
 
   function restoreTemplatesDraft(draft) {
@@ -1697,10 +1730,12 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   }
 
   function syncSaveFlairButtonState() {
-    if (!saveFlairBtn) {
-      return;
+    for (const button of [saveFlairBtn, saveInstructionsBtn]) {
+      if (!button) {
+        continue;
+      }
+      button.disabled = isBusy || isSavingFlairSettings;
     }
-    saveFlairBtn.disabled = isBusy || isSavingFlairSettings;
   }
 
   function postWithBusy(message) {
@@ -1800,7 +1835,7 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       const uiDrafts = captureUiDrafts();
       const hadPriorState = stateInitialized;
       const previousSubredditName = state ? normalizeSubredditName(state.subredditName) : '';
-      const preserveSettingsScroll = activePrimaryTab === 'settings' && activeSettingsTab === 'general';
+      const preserveSettingsScroll = activePrimaryTab === 'settings';
       const viewportScrollTop = preserveSettingsScroll ? getViewportScrollTop() : 0;
       state = message.payload;
       flairTemplateValidationOverride = null;
@@ -1934,8 +1969,24 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     return resolvedTab;
   }
 
+  function setInstructionsLanguage(language) {
+    activeInstructionLanguage = language === 'es' || language === 'fr' ? language : 'en';
+    for (const [name, panel] of Object.entries(instructionLanguagePanels)) {
+      if (!panel) {
+        continue;
+      }
+      panel.classList.toggle('hidden', name !== activeInstructionLanguage);
+    }
+    for (const button of instructionLanguageTabButtons) {
+      const isActive = String(button.dataset.instructionLanguage || 'en') === activeInstructionLanguage;
+      button.classList.toggle('settings-language-tab-btn-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    }
+  }
+
   function setSettingsTab(tabName) {
-    activeSettingsTab = tabName === 'templates' || tabName === 'themes' ? tabName : 'general';
+    activeSettingsTab =
+      tabName === 'instructions' || tabName === 'templates' || tabName === 'themes' ? tabName : 'general';
     for (const [name, panel] of Object.entries(settingsPanels)) {
       if (!panel) {
         continue;
@@ -1953,6 +2004,10 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     }
     if (activeSettingsTab === 'general' && tabPanels.settings && !tabPanels.settings.classList.contains('hidden')) {
       void ensureApprovalFlairOptionsLoaded();
+      return;
+    }
+    if (activeSettingsTab === 'instructions') {
+      setInstructionsLanguage(activeInstructionLanguage);
     }
   }
 
@@ -3067,11 +3122,21 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       const count = Number(state.config.requiredPhotoCount || 2);
       requiredPhotoCountInput.value = `${count >= 1 && count <= 3 ? count : 2}`;
     }
+    if (photoInstructionsDefaultLanguageInput) {
+      photoInstructionsDefaultLanguageInput.value = state.config.photoInstructionsDefaultLanguage || 'en';
+    }
     if (photoInstructionsInput) {
       photoInstructionsInput.value = state.config.photoInstructions || '';
     }
+    if (photoInstructionsEsInput) {
+      photoInstructionsEsInput.value = state.config.photoInstructionsEs || '';
+    }
+    if (photoInstructionsFrInput) {
+      photoInstructionsFrInput.value = state.config.photoInstructionsFr || '';
+    }
     renderApprovalFlairPicker();
     renderFlairTemplateValidationFeedback();
+    setInstructionsLanguage(activeInstructionLanguage);
   }
 
   function renderTemplates() {
@@ -4528,9 +4593,17 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     });
   }
 
-  saveFlairBtn.addEventListener('click', () => {
-    void saveFlairSettings();
-  });
+  if (saveFlairBtn) {
+    saveFlairBtn.addEventListener('click', () => {
+      void saveFlairSettings();
+    });
+  }
+
+  if (saveInstructionsBtn) {
+    saveInstructionsBtn.addEventListener('click', () => {
+      void saveFlairSettings();
+    });
+  }
 
   saveTemplatesBtn.addEventListener('click', () => {
     postWithBusy({
@@ -4690,6 +4763,12 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       if (tab) {
         setSettingsTab(tab);
       }
+    });
+  }
+
+  for (const btn of instructionLanguageTabButtons) {
+    btn.addEventListener('click', () => {
+      setInstructionsLanguage(btn.dataset.instructionLanguage);
     });
   }
 

--- a/webroot/mod-panel.js
+++ b/webroot/mod-panel.js
@@ -16,6 +16,9 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   };
 
   const settingsTabButtons = Array.from(document.querySelectorAll('.settings-tab-btn'));
+  const settingsTabsShell = document.getElementById('settings-tabs-shell');
+  const settingsTabsNav = document.getElementById('settings-tabs');
+  const settingsTabsScrollHint = document.getElementById('settings-tabs-scroll-hint');
   const settingsPanels = {
     general: document.getElementById('settings-panel-general'),
     instructions: document.getElementById('settings-panel-instructions'),
@@ -1966,6 +1969,9 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       }
     }
     activePrimaryTab = resolvedTab;
+    window.requestAnimationFrame(() => {
+      updateSettingsTabsScrollAffordance();
+    });
     return resolvedTab;
   }
 
@@ -1981,6 +1987,31 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       const isActive = String(button.dataset.instructionLanguage || 'en') === activeInstructionLanguage;
       button.classList.toggle('settings-language-tab-btn-active', isActive);
       button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    }
+  }
+
+  function updateSettingsTabsScrollAffordance() {
+    if (!settingsTabsShell || !settingsTabsNav) {
+      return;
+    }
+    const settingsVisible = Boolean(tabPanels.settings && !tabPanels.settings.classList.contains('hidden'));
+    if (!settingsVisible) {
+      settingsTabsShell.dataset.scrollLeft = 'false';
+      settingsTabsShell.dataset.scrollRight = 'false';
+      if (settingsTabsScrollHint) {
+        settingsTabsScrollHint.classList.add('hidden');
+      }
+      return;
+    }
+
+    const overflow = settingsTabsNav.scrollWidth - settingsTabsNav.clientWidth > 8;
+    const canScrollLeft = settingsTabsNav.scrollLeft > 6;
+    const canScrollRight =
+      settingsTabsNav.scrollLeft + settingsTabsNav.clientWidth < settingsTabsNav.scrollWidth - 6;
+    settingsTabsShell.dataset.scrollLeft = canScrollLeft ? 'true' : 'false';
+    settingsTabsShell.dataset.scrollRight = canScrollRight ? 'true' : 'false';
+    if (settingsTabsScrollHint) {
+      settingsTabsScrollHint.classList.toggle('hidden', !overflow || !canScrollRight);
     }
   }
 
@@ -2009,6 +2040,9 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     if (activeSettingsTab === 'instructions') {
       setInstructionsLanguage(activeInstructionLanguage);
     }
+    window.requestAnimationFrame(() => {
+      updateSettingsTabsScrollAffordance();
+    });
   }
 
   function formatDateInputValue(date) {
@@ -4821,6 +4855,18 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       prefersDarkMedia.addListener(onColorSchemeChange);
     }
   }
+
+  if (settingsTabsNav) {
+    settingsTabsNav.addEventListener('scroll', () => {
+      updateSettingsTabsScrollAffordance();
+    }, { passive: true });
+  }
+
+  window.addEventListener('resize', () => {
+    window.requestAnimationFrame(() => {
+      updateSettingsTabsScrollAffordance();
+    });
+  });
 
   window.addEventListener('pagehide', closeRealtimeSubscription);
 


### PR DESCRIPTION
## Summary
- add English, Spanish, and French photo-instruction fields to moderator settings
- add a configurable default instruction language with safe fallback behavior in the hub
- localize the photo-instructions title, subtitle, and scroll hint in the shared popup/Android view
- improve moderator panel UX for instruction editing and settings-tab horizontal scroll affordance

## Testing
- `npm test`
- `npm run build`