### PR TITLE
Add batch review actions to the modqueue

### DIFF
--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -4,6 +4,8 @@ import test from 'node:test';
 import {
   assertCanReview,
   approveVerification,
+  batchReviewVerifications,
+  buildBatchReviewToast,
   buildModeratorUpdateNotice,
   checkVerificationFlair,
   clearExpiredPendingClaim,
@@ -27,6 +29,7 @@ import {
   searchApprovedRecords,
   searchAuditEntries,
   searchHistoryRecords,
+  normalizeBatchReviewVerificationIds,
   normalizeModmailConversationId,
   normalizeMaxDenialsBeforeBlockSetting,
   normalizeSubmittedPhotoUrl,
@@ -4148,6 +4151,138 @@ test('denyVerification leaves the record pending when user validation has a tran
   assert.equal(reviewContext.createConversationCalls.length, 0);
   assert.equal(reviewContext.addModNoteCalls.length, 0);
   assert.equal(reviewContext.hashStore.get(denialCountTestKey(reviewContext.subredditId))?.size ?? 0, 0);
+});
+
+test('normalizeBatchReviewVerificationIds dedupes, drops empty IDs, and caps accepted IDs', () => {
+  const normalized = normalizeBatchReviewVerificationIds(['one', ' ', 'one', 'two', null, 'three'], 2);
+
+  assert.deepEqual(normalized.ids, ['one', 'two']);
+  assert.equal(normalized.duplicateOrEmptyCount, 3);
+  assert.equal(normalized.truncatedCount, 1);
+});
+
+test('buildBatchReviewToast summarizes partial batch outcomes', () => {
+  const toast = buildBatchReviewToast({
+    action: 'approve',
+    requestedCount: 11,
+    acceptedCount: 10,
+    duplicateOrEmptyCount: 1,
+    truncatedCount: 0,
+    terminalVerificationIds: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+    counts: {
+      completed: 8,
+      failed: 1,
+      validation_retry: 0,
+      invalid_account_removed: 0,
+      banned_confirmation_required: 1,
+    },
+    items: [],
+  });
+
+  assert.equal(toast.text, 'Approved 8; 1 needs individual banned-user confirmation; 1 failed; 1 skipped.');
+  assert.equal(toast.tone, 'error');
+});
+
+test('batchReviewVerifications approves selected records with one shared approval flair', async () => {
+  const reviewContext = createReviewActionContext({
+    multipleApprovalFlairsEnabled: true,
+    initialHashes: {
+      [subredditConfigTestKey('t5_example')]: {
+        additional_approval_flairs_json: JSON.stringify([
+          { templateId: 'def-456', label: 'Trusted', text: 'Trusted Verified' },
+          { templateId: 'ghi-789', label: 'VIP', text: 'VIP Verified' },
+        ]),
+      },
+    },
+  });
+  const secondRecord = buildRecord({
+    id: 'verification_pending_2',
+    username: 'second_user',
+    userId: 't2_second',
+    subredditId: reviewContext.subredditId,
+    subredditName: reviewContext.record.subredditName,
+    submittedAt: '2026-03-11T16:00:00.000Z',
+  });
+  reviewContext.redisStore.set(
+    verificationRecordTestKey(reviewContext.subredditId, secondRecord.id),
+    JSON.stringify(secondRecord)
+  );
+  reviewContext.redisStore.set(userPendingTestKey(reviewContext.subredditId, secondRecord.username), secondRecord.id);
+  reviewContext.redisStore.set(userLatestTestKey(reviewContext.subredditId, secondRecord.username), secondRecord.id);
+  ensureTestZSet(reviewContext.zsetStore, pendingIndexTestKey(reviewContext.subredditId)).set(
+    secondRecord.id,
+    new Date(secondRecord.submittedAt).getTime()
+  );
+
+  const result = await batchReviewVerifications(reviewContext.context as never, {
+    action: 'approve',
+    verificationIds: [reviewContext.record.id, secondRecord.id],
+    selectedFlairTemplateId: 'ghi-789',
+  });
+
+  assert.equal(result.counts.completed, 2);
+  assert.deepEqual(result.terminalVerificationIds.sort(), [reviewContext.record.id, secondRecord.id].sort());
+  assert.equal(reviewContext.getParsedRecord(reviewContext.record.id)?.status, 'approved');
+  assert.equal(reviewContext.getParsedRecord(secondRecord.id)?.status, 'approved');
+  assert.equal(reviewContext.setUserFlairCalls.length, 2);
+  assert.deepEqual(
+    reviewContext.setUserFlairCalls.map((call) => call.flairTemplateId),
+    ['ghi-789', 'ghi-789']
+  );
+});
+
+test('batchReviewVerifications denies selected records with one shared reason and notes', async () => {
+  const reviewContext = createReviewActionContext();
+  const secondRecord = buildRecord({
+    id: 'verification_pending_2',
+    username: 'second_user',
+    userId: 't2_second',
+    subredditId: reviewContext.subredditId,
+    subredditName: reviewContext.record.subredditName,
+    submittedAt: '2026-03-11T16:00:00.000Z',
+  });
+  reviewContext.redisStore.set(
+    verificationRecordTestKey(reviewContext.subredditId, secondRecord.id),
+    JSON.stringify(secondRecord)
+  );
+  reviewContext.redisStore.set(userPendingTestKey(reviewContext.subredditId, secondRecord.username), secondRecord.id);
+  reviewContext.redisStore.set(userLatestTestKey(reviewContext.subredditId, secondRecord.username), secondRecord.id);
+  ensureTestZSet(reviewContext.zsetStore, pendingIndexTestKey(reviewContext.subredditId)).set(
+    secondRecord.id,
+    new Date(secondRecord.submittedAt).getTime()
+  );
+
+  const result = await batchReviewVerifications(reviewContext.context as never, {
+    action: 'deny',
+    verificationIds: [reviewContext.record.id, secondRecord.id],
+    reason: 'reason_2',
+    moderatorNotes: 'Shared denial note',
+  });
+
+  assert.equal(result.counts.completed, 2);
+  assert.deepEqual(result.terminalVerificationIds.sort(), [reviewContext.record.id, secondRecord.id].sort());
+  assert.equal(reviewContext.getParsedRecord(reviewContext.record.id)?.denyReason, 'reason_2');
+  assert.equal(reviewContext.getParsedRecord(secondRecord.id)?.denyReason, 'reason_2');
+  assert.equal(reviewContext.getParsedRecord(reviewContext.record.id)?.denyNotes, 'Shared denial note');
+  assert.equal(reviewContext.getParsedRecord(secondRecord.id)?.denyNotes, 'Shared denial note');
+  assert.equal(reviewContext.hashStore.get(denialCountTestKey(reviewContext.subredditId))?.get('example_user'), '1');
+  assert.equal(reviewContext.hashStore.get(denialCountTestKey(reviewContext.subredditId))?.get('second_user'), '1');
+});
+
+test('batchReviewVerifications removes terminal denials even when side effects fail', async () => {
+  const reviewContext = createReviewActionContext({
+    createConversationResponses: [new Error('modmail unavailable')],
+  });
+
+  const result = await batchReviewVerifications(reviewContext.context as never, {
+    action: 'deny',
+    verificationIds: [reviewContext.record.id],
+    reason: 'reason_1',
+  });
+
+  assert.equal(result.counts.failed, 1);
+  assert.deepEqual(result.terminalVerificationIds, [reviewContext.record.id]);
+  assert.equal(reviewContext.getParsedRecord()?.status, 'denied');
 });
 
 test('approveVerification clears reopened metadata when an invalid reopened review is removed', async () => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -357,6 +357,47 @@ type ActionResult = {
   manualBlockOutcome?: ManualBlockOutcome;
 };
 
+const MAX_BATCH_REVIEW_ITEMS = 25;
+const BATCH_REVIEW_CONCURRENCY = 3;
+
+type BatchReviewAction = 'approve' | 'deny';
+type BatchReviewItemStatus =
+  | 'completed'
+  | 'failed'
+  | 'validation_retry'
+  | 'invalid_account_removed'
+  | 'banned_confirmation_required';
+
+type NormalizedBatchReviewIds = {
+  ids: string[];
+  duplicateOrEmptyCount: number;
+  truncatedCount: number;
+};
+
+type BatchReviewItemResult = {
+  verificationId: string;
+  status: BatchReviewItemStatus;
+  terminal: boolean;
+  username?: string;
+  message?: string;
+};
+
+type BatchReviewResult = {
+  action: BatchReviewAction;
+  requestedCount: number;
+  acceptedCount: number;
+  duplicateOrEmptyCount: number;
+  truncatedCount: number;
+  terminalVerificationIds: string[];
+  counts: Record<BatchReviewItemStatus, number>;
+  items: BatchReviewItemResult[];
+};
+
+type BatchReviewToast = {
+  text: string;
+  tone: 'success' | 'error' | 'info';
+};
+
 type DeleteDataResult = {
   deletedCount: number;
   flairRemovedFrom: string[];
@@ -3066,6 +3107,205 @@ async function denyVerification(
       manualBlockOutcome,
     };
   });
+}
+
+function normalizeBatchReviewVerificationIds(
+  values: unknown,
+  maxItems = MAX_BATCH_REVIEW_ITEMS
+): NormalizedBatchReviewIds {
+  const rawValues = Array.isArray(values) ? values : [];
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  let duplicateOrEmptyCount = 0;
+
+  for (const value of rawValues) {
+    const id = String(value ?? '').trim();
+    if (!id || seen.has(id)) {
+      duplicateOrEmptyCount += 1;
+      continue;
+    }
+    seen.add(id);
+    ids.push(id);
+  }
+
+  const limit = Math.max(0, Math.floor(maxItems));
+  return {
+    ids: ids.slice(0, limit),
+    duplicateOrEmptyCount,
+    truncatedCount: Math.max(0, ids.length - limit),
+  };
+}
+
+function emptyBatchReviewCounts(): Record<BatchReviewItemStatus, number> {
+  return {
+    completed: 0,
+    failed: 0,
+    validation_retry: 0,
+    invalid_account_removed: 0,
+    banned_confirmation_required: 0,
+  };
+}
+
+function classifyBatchReviewItem(action: BatchReviewAction, verificationId: string, result: ActionResult): BatchReviewItemResult {
+  if (result.outcome === 'validation_retry') {
+    return {
+      verificationId,
+      status: 'validation_retry',
+      terminal: false,
+      username: result.username,
+      message: result.outcomeReason,
+    };
+  }
+  if (result.outcome === 'banned_confirmation_required') {
+    return {
+      verificationId,
+      status: 'banned_confirmation_required',
+      terminal: false,
+      username: result.username,
+      message: 'Approval requires individual banned-user confirmation.',
+    };
+  }
+  if (result.outcome === 'invalid_account_removed') {
+    return {
+      verificationId,
+      status: 'invalid_account_removed',
+      terminal: true,
+      username: result.username,
+      message: result.outcomeReason,
+    };
+  }
+
+  const failedApproval =
+    action === 'approve' &&
+    (!result.applied || result.flair.status === 'failed' || result.modmail.status === 'failed' || result.modNote.status === 'failed');
+  const failedDenial = action === 'deny' && (result.modmail.status === 'failed' || result.modNote.status === 'failed');
+  if (failedApproval || failedDenial) {
+    return {
+      verificationId,
+      status: 'failed',
+      terminal: result.applied,
+      username: result.username,
+      message:
+        result.flair.reason ??
+        result.modmail.reason ??
+        result.modNote.reason ??
+        (action === 'approve' ? 'Approval did not complete.' : 'Denial completed with issues.'),
+    };
+  }
+
+  return {
+    verificationId,
+    status: 'completed',
+    terminal: true,
+    username: result.username,
+  };
+}
+
+async function batchReviewVerifications(
+  context: Devvit.Context,
+  input: {
+    action: BatchReviewAction;
+    verificationIds: unknown;
+    selectedFlairTemplateId?: string;
+    reason?: DenyReason | null;
+    moderatorNotes?: string;
+  }
+): Promise<BatchReviewResult> {
+  const normalized = normalizeBatchReviewVerificationIds(input.verificationIds);
+  if (normalized.ids.length === 0) {
+    throw new Error('Select at least one verification to review.');
+  }
+  if (input.action !== 'approve' && input.action !== 'deny') {
+    throw new Error('Select a valid batch action.');
+  }
+  if (input.action === 'deny' && !input.reason) {
+    throw new Error('Select a valid denial reason.');
+  }
+
+  const counts = emptyBatchReviewCounts();
+  const items: BatchReviewItemResult[] = new Array(normalized.ids.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= normalized.ids.length) {
+        return;
+      }
+
+      const verificationId = normalized.ids[index]!;
+      try {
+        const result =
+          input.action === 'approve'
+            ? await approveVerification(context, verificationId, false, input.selectedFlairTemplateId)
+            : await denyVerification(context, verificationId, input.reason!, input.moderatorNotes ?? '');
+        items[index] = classifyBatchReviewItem(input.action, verificationId, result);
+      } catch (error) {
+        items[index] = {
+          verificationId,
+          status: 'failed',
+          terminal: false,
+          message: errorText(error),
+        };
+      }
+    }
+  }
+
+  const workerCount = Math.min(BATCH_REVIEW_CONCURRENCY, normalized.ids.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  const completedItems = items.filter(Boolean);
+  for (const item of completedItems) {
+    counts[item.status] += 1;
+  }
+
+  return {
+    action: input.action,
+    requestedCount: Array.isArray(input.verificationIds) ? input.verificationIds.length : 0,
+    acceptedCount: normalized.ids.length,
+    duplicateOrEmptyCount: normalized.duplicateOrEmptyCount,
+    truncatedCount: normalized.truncatedCount,
+    terminalVerificationIds: completedItems.filter((item) => item.terminal).map((item) => item.verificationId),
+    counts,
+    items: completedItems,
+  };
+}
+
+function pluralizeBatchCount(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function buildBatchReviewToast(result: BatchReviewResult): BatchReviewToast {
+  const parts: string[] = [];
+  const actionLabel = result.action === 'approve' ? 'Approved' : 'Denied';
+  if (result.counts.completed > 0) {
+    parts.push(`${actionLabel} ${result.counts.completed}`);
+  }
+  if (result.counts.invalid_account_removed > 0) {
+    parts.push(`${pluralizeBatchCount(result.counts.invalid_account_removed, 'invalid account')} removed`);
+  }
+  if (result.counts.banned_confirmation_required > 0) {
+    parts.push(
+      `${result.counts.banned_confirmation_required} ${
+        result.counts.banned_confirmation_required === 1 ? 'needs' : 'need'
+      } individual banned-user confirmation`
+    );
+  }
+  if (result.counts.validation_retry > 0) {
+    parts.push(`${result.counts.validation_retry} need retry`);
+  }
+  if (result.counts.failed > 0) {
+    parts.push(`${result.counts.failed} failed`);
+  }
+  const skipped = result.duplicateOrEmptyCount + result.truncatedCount;
+  if (skipped > 0) {
+    parts.push(`${skipped} skipped`);
+  }
+
+  const text = parts.length > 0 ? parts.join('; ') + '.' : 'No selected verifications were changed.';
+  const tone = result.counts.failed > 0 || result.counts.validation_retry > 0 ? 'error' : result.counts.completed > 0 ? 'success' : 'info';
+  return { text, tone };
 }
 
 async function reopenDeniedVerification(
@@ -8943,6 +9183,7 @@ export {
   THEME_PRESETS,
   USER_VALIDATION_CRON,
   USER_VALIDATION_JOB_NAME,
+  MAX_BATCH_REVIEW_ITEMS,
   buildSubmitVerificationForm,
   deleteVerificationDataFormDefinition,
   toModPanelState,
@@ -8953,6 +9194,9 @@ export {
   deleteCurrentUserVerificationData,
   approveVerification,
   denyVerification,
+  batchReviewVerifications,
+  buildBatchReviewToast,
+  normalizeBatchReviewVerificationIds,
   setPendingClaimState,
   reopenDeniedVerification,
   cancelReopenedVerification,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,9 @@ import { context, createServer, getServerPort, realtime, reddit, redis, schedule
 
 import {
   assertCanReview,
+  batchReviewVerifications,
   blockUserForModerator,
+  buildBatchReviewToast,
   buildModeratorUpdateNotice,
   buildSubmitVerificationForm,
   cancelReopenedVerification,
@@ -622,6 +624,40 @@ app.post('/api/mod/deny', async (req, res) => {
         type: 'removePending',
         verificationId,
       },
+    });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+app.post('/api/mod/batch-review', async (req, res) => {
+  try {
+    const action = String(req.body?.action ?? '').trim();
+    const appContext = currentContext();
+    if (action !== 'approve' && action !== 'deny') {
+      throw httpError(400, 'Select a valid batch action.');
+    }
+    const reason = action === 'deny' ? parseDenyReason(String(req.body?.reason ?? '').trim()) : null;
+    if (action === 'deny' && !reason) {
+      throw httpError(400, 'Select a valid denial reason.');
+    }
+    const result = await batchReviewVerifications(appContext, {
+      action,
+      verificationIds: req.body?.verificationIds,
+      selectedFlairTemplateId: String(req.body?.selectedFlairTemplateId ?? '').trim(),
+      reason,
+      moderatorNotes: String(req.body?.moderatorNotes ?? '').trim(),
+    });
+    const mutation =
+      result.terminalVerificationIds.length > 0
+        ? {
+            type: 'removePendingMany',
+            verificationIds: result.terminalVerificationIds,
+          }
+        : undefined;
+    sendFastModRefreshResponse(res, appContext, buildBatchReviewToast(result), {
+      batchReview: result,
+      ...(mutation ? { mutation } : {}),
     });
   } catch (error) {
     sendError(res, error);

--- a/webroot/mod-panel.css
+++ b/webroot/mod-panel.css
@@ -58,6 +58,15 @@ body.mod-panel-page {
     linear-gradient(180deg, color-mix(in srgb, var(--panel-bg) 94%, #000000 6%), var(--panel-bg));
 }
 
+body.mod-panel-page.batch-review-floating-active {
+  padding-bottom: 112px;
+}
+
+body.mod-panel-page.batch-review-approve-expanded,
+body.mod-panel-page.batch-review-deny-expanded {
+  padding-bottom: 176px;
+}
+
 body.mod-panel-page::before {
   content: "";
   position: fixed;
@@ -1049,6 +1058,74 @@ textarea {
   padding-bottom: 16px;
 }
 
+.batch-review-toolbar {
+  position: fixed;
+  right: max(14px, calc((100vw - 1120px) / 2 + 14px));
+  bottom: 14px;
+  left: max(14px, calc((100vw - 1120px) / 2 + 14px));
+  z-index: 39;
+  display: grid;
+  gap: 12px;
+  max-width: 1092px;
+  margin: 0 auto;
+  padding: 13px 14px;
+  border: 1px solid color-mix(in srgb, var(--panel-border-strong) 70%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--panel-surface) 94%, black 6%);
+  box-shadow: 0 18px 50px color-mix(in srgb, #000 30%, transparent);
+  backdrop-filter: blur(16px);
+}
+
+.batch-review-toolbar .batch-approval-flair-wrap,
+.batch-review-toolbar .batch-deny-field {
+  display: none;
+}
+
+.batch-review-toolbar.batch-deny-expanded .batch-deny-field {
+  display: grid;
+}
+
+.batch-review-toolbar.batch-approve-expanded .batch-approval-flair-wrap {
+  display: grid;
+}
+
+.batch-review-summary,
+.batch-review-actions {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.batch-review-summary {
+  justify-content: space-between;
+}
+
+.batch-review-kicker {
+  margin-bottom: 3px;
+}
+
+.batch-selected-count {
+  color: var(--text);
+  font-weight: 720;
+}
+
+.batch-review-actions .field-stack {
+  min-width: min(210px, 100%);
+}
+
+.batch-review-actions {
+  justify-content: flex-end;
+}
+
+.batch-deny-notes-stack {
+  flex: 1 1 260px;
+}
+
+.batch-deny-notes-stack .field-textarea {
+  min-height: 38px;
+}
+
 .queue-list-card .stack {
   margin-top: 0;
 }
@@ -1080,6 +1157,29 @@ textarea {
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
+}
+
+.pending-title-left {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+}
+
+.pending-select-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  min-height: 24px;
+  padding-top: 1px;
+}
+
+.pending-select-toggle input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--primary);
 }
 
 .pending-title-primary {
@@ -2423,6 +2523,55 @@ textarea {
 }
 
 @media (max-width: 560px) {
+  body.mod-panel-page.batch-review-floating-active {
+    padding-bottom: 96px;
+  }
+
+  body.mod-panel-page.batch-review-approve-expanded,
+  body.mod-panel-page.batch-review-deny-expanded {
+    padding-bottom: 250px;
+  }
+
+  .batch-review-toolbar {
+    right: 10px;
+    bottom: 10px;
+    left: 10px;
+    max-height: calc(100vh - 20px);
+    max-height: calc(100dvh - 20px);
+    overflow-y: auto;
+    padding: 12px;
+  }
+
+  .batch-review-kicker {
+    display: none;
+  }
+
+  .batch-review-summary,
+  .batch-review-actions {
+    align-items: stretch;
+  }
+
+  .batch-review-toolbar:not(.batch-approve-expanded):not(.batch-deny-expanded) {
+    grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+    align-items: center;
+    gap: 8px;
+  }
+
+  .batch-review-toolbar:not(.batch-approve-expanded):not(.batch-deny-expanded) .batch-review-summary {
+    min-width: max-content;
+  }
+
+  .batch-review-toolbar:not(.batch-approve-expanded):not(.batch-deny-expanded) .batch-review-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .batch-review-actions .field-stack,
+  .batch-review-actions .btn {
+    width: 100%;
+  }
+
   .settings-tabs-shell::before,
   .settings-tabs-shell::after {
     width: 28px;

--- a/webroot/mod-panel.html
+++ b/webroot/mod-panel.html
@@ -98,6 +98,30 @@
               </div>
             </div>
             <div class="content-card queue-list-card">
+              <div id="batch-review-toolbar" class="batch-review-toolbar hidden" aria-live="polite">
+                <div class="batch-review-summary">
+                  <div>
+                    <p class="group-kicker batch-review-kicker">Batch actions</p>
+                    <span id="batch-selected-count" class="batch-selected-count">0 selected</span>
+                  </div>
+                </div>
+                <div class="batch-review-actions">
+                  <div id="batch-approval-flair-wrap" class="field-stack batch-approval-flair-wrap hidden">
+                    <label class="field-label" for="batch-approval-flair">Approval flair</label>
+                    <select id="batch-approval-flair" class="field-select"></select>
+                  </div>
+                  <button id="batch-approve-btn" class="btn btn-success" type="button">Approve selected</button>
+                  <div class="field-stack batch-deny-field">
+                    <label class="field-label" for="batch-deny-reason">Denial reason</label>
+                    <select id="batch-deny-reason" class="field-select"></select>
+                  </div>
+                  <div class="field-stack batch-deny-field batch-deny-notes-stack">
+                    <label class="field-label" for="batch-deny-notes">Denial notes</label>
+                    <textarea id="batch-deny-notes" class="field-textarea" rows="2" placeholder="Optional shared notes"></textarea>
+                  </div>
+                  <button id="batch-deny-btn" class="btn btn-danger" type="button">Deny selected</button>
+                </div>
+              </div>
               <div id="pending-list" class="stack"></div>
             </div>
           </div>
@@ -476,7 +500,7 @@
 
               <p class="instructions-settings-note muted small">
                 We recommend using
-                <a href="https://translate.google.com/" target="_blank" rel="noopener noreferrer">Google Translate</a>
+                <a href="https://translate.google.com/" target="_blank" rel="noopener noreferrer">Google Translate</a> or <a href="https://www.deepl.com/translator" target="_blank" rel="noopener noreferrer">DeepL Translator</a>
                 to help provide instructions in multiple languages for non-native speakers.
               </p>
 

--- a/webroot/mod-panel.js
+++ b/webroot/mod-panel.js
@@ -46,6 +46,14 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   const pendingSearchUserInput = document.getElementById('pending-search-user');
   const pendingSearchHint = document.getElementById('pending-search-hint');
   const pendingSlaButtons = Array.from(document.querySelectorAll('.pending-sla-btn'));
+  const batchReviewToolbar = document.getElementById('batch-review-toolbar');
+  const batchSelectedCount = document.getElementById('batch-selected-count');
+  const batchApprovalFlairWrap = document.getElementById('batch-approval-flair-wrap');
+  const batchApprovalFlairSelect = document.getElementById('batch-approval-flair');
+  const batchApproveBtn = document.getElementById('batch-approve-btn');
+  const batchDenyReasonSelect = document.getElementById('batch-deny-reason');
+  const batchDenyNotesInput = document.getElementById('batch-deny-notes');
+  const batchDenyBtn = document.getElementById('batch-deny-btn');
   const historyViewButtons = Array.from(document.querySelectorAll('.history-view-btn'));
   const historyPanelRecords = document.getElementById('history-panel-records');
   const historyPanelApproved = document.getElementById('history-panel-approved');
@@ -216,6 +224,12 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   let isSavingFlairSettings = false;
   let pendingUsernameFilter = '';
   let selectedPendingSlaFilter = 'all';
+  let selectedPendingIds = new Set();
+  let batchApprovalFlairDraft = '';
+  let batchApprovalOptionsExpanded = false;
+  let batchDenyReasonDraft = '';
+  let batchDenyNotesDraft = '';
+  let batchDenyOptionsExpanded = false;
   let activePrimaryTab = 'pending';
   let activeHistoryView = 'records';
   let activeSettingsTab = 'general';
@@ -279,6 +293,7 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   const themeSubredditScope = (queryParams.get('subredditId') || 'default').trim().toLowerCase() || 'default';
   const THEME_SNAPSHOT_KEY = `nsfw-verify-theme-snapshot-v1:${themeSubredditScope}`;
   const ACCOUNT_AGE_WARNING_DAYS = 14;
+  const MAX_BATCH_REVIEW_ITEMS = 25;
   const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
   const LOCAL_REALTIME_REFRESH_SUPPRESSION_WINDOW_MS = 2500;
   const STATS_AUTO_REFRESH_INTERVAL_MS = 20 * 1000;
@@ -407,15 +422,24 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       return;
     }
 
-    if (mutation.type === 'removePending') {
-      const verificationId = String(mutation.verificationId || '').trim();
-      if (!verificationId || !Array.isArray(state.pending)) {
+    if (mutation.type === 'removePending' || mutation.type === 'removePendingMany') {
+      const verificationIds =
+        mutation.type === 'removePendingMany'
+          ? Array.isArray(mutation.verificationIds)
+            ? mutation.verificationIds.map((id) => String(id || '').trim()).filter(Boolean)
+            : []
+          : [String(mutation.verificationId || '').trim()].filter(Boolean);
+      const idsToRemove = new Set(verificationIds);
+      if (idsToRemove.size === 0 || !Array.isArray(state.pending)) {
         return;
       }
-      const nextPending = state.pending.filter((item) => String(item && item.id || '') !== verificationId);
+      const nextPending = state.pending.filter((item) => !idsToRemove.has(String(item && item.id || '')));
       const removedCount = state.pending.length - nextPending.length;
       if (removedCount <= 0) {
         return;
+      }
+      for (const id of idsToRemove) {
+        selectedPendingIds.delete(id);
       }
       const currentPendingCount = Number.isFinite(Number(state.pendingCount)) ? Number(state.pendingCount) : state.pending.length;
       state = {
@@ -741,6 +765,10 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       templateId: option.templateId,
       label: option.label || (index === 0 ? 'Default approval flair' : option.templateId),
     }));
+  }
+
+  function shouldBatchApprovalAskForFlair(approvalFlairChoices = getConfiguredApprovalFlairChoices()) {
+    return Boolean(state && state.config && state.config.multipleApprovalFlairsEnabled === true && approvalFlairChoices.length > 1);
   }
 
   function getSavedFlairTemplateValidation() {
@@ -1616,6 +1644,18 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
         return;
       }
 
+      if (message.type === 'batchReview') {
+        const payload = await requestJson('/api/mod/batch-review', {
+          action: message.action,
+          verificationIds: message.verificationIds,
+          selectedFlairTemplateId: message.selectedFlairTemplateId,
+          reason: message.reason,
+          moderatorNotes: message.moderatorNotes,
+        });
+        applyMutationApiState(payload);
+        return;
+      }
+
       if (message.type === 'claimPending') {
         applyMutationApiState(await requestJson('/api/mod/claim', { verificationId: message.verificationId }));
         return;
@@ -2205,6 +2245,188 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     }
   }
 
+  function getFilteredPendingItems() {
+    if (!state || !Array.isArray(state.pending)) {
+      return [];
+    }
+    return state.pending.filter(matchesPendingFilters).sort((left, right) => getPendingSortScore(left) - getPendingSortScore(right));
+  }
+
+  function isPendingItemClaimedByOther(item) {
+    const viewerUsername = normalizeUsernameForCompare(state ? state.viewerUsername : '');
+    const claimedByNormalized = normalizeUsernameForCompare(item && item.claimedBy);
+    return Boolean(claimedByNormalized && (!viewerUsername || claimedByNormalized !== viewerUsername));
+  }
+
+  function isPendingItemDenyEligible(item) {
+    return Boolean(item && !item.parentVerificationId && !isPendingItemClaimedByOther(item));
+  }
+
+  function pruneSelectedPendingIds() {
+    if (!state || !Array.isArray(state.pending)) {
+      selectedPendingIds.clear();
+      return;
+    }
+    const selectableIds = new Set(
+      state.pending
+        .filter((item) => item && item.id && !isPendingItemClaimedByOther(item))
+        .map((item) => String(item.id))
+    );
+    for (const id of Array.from(selectedPendingIds)) {
+      if (!selectableIds.has(id)) {
+        selectedPendingIds.delete(id);
+      }
+    }
+  }
+
+  function getSelectedPendingItems() {
+    if (!state || !Array.isArray(state.pending) || selectedPendingIds.size === 0) {
+      return [];
+    }
+    return state.pending.filter((item) => selectedPendingIds.has(String(item && item.id || '')) && !isPendingItemClaimedByOther(item));
+  }
+
+  function syncPendingSelectionCheckboxes() {
+    const atSelectionLimit = selectedPendingIds.size >= MAX_BATCH_REVIEW_ITEMS;
+    for (const checkbox of document.querySelectorAll('input[data-role="pending-select"]')) {
+      const id = String(checkbox.value || '').trim();
+      const checked = selectedPendingIds.has(id);
+      checkbox.checked = checked;
+      checkbox.disabled = !checked && atSelectionLimit;
+      checkbox.title = checkbox.disabled ? `Batch actions are limited to ${MAX_BATCH_REVIEW_ITEMS} requests.` : '';
+    }
+  }
+
+  function replaceSelectOptions(select, options, placeholderText) {
+    if (!select) {
+      return '';
+    }
+    const previousValue = String(select.value || '');
+    select.innerHTML = '';
+    if (placeholderText) {
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = placeholderText;
+      select.appendChild(placeholder);
+    }
+    for (const optionValue of options) {
+      const option = document.createElement('option');
+      option.value = optionValue.value;
+      option.textContent = optionValue.label;
+      select.appendChild(option);
+    }
+    if (previousValue && options.some((option) => option.value === previousValue)) {
+      select.value = previousValue;
+      return previousValue;
+    }
+    return '';
+  }
+
+  function syncBatchToolbarState() {
+    pruneSelectedPendingIds();
+    const selectedItems = getSelectedPendingItems();
+    const selectedCount = selectedItems.length;
+    const denyEligibleCount = selectedItems.filter(isPendingItemDenyEligible).length;
+    const approvalsAllowed = canApprovePendingItems();
+    const enabledReasons = getEnabledDenyReasons();
+    const approvalFlairChoices = getConfiguredApprovalFlairChoices();
+    const approvalFlairRequired = shouldBatchApprovalAskForFlair(approvalFlairChoices);
+    const showBatchToolbar = selectedCount >= 2;
+    if (!showBatchToolbar) {
+      batchApprovalOptionsExpanded = false;
+      batchDenyOptionsExpanded = false;
+    } else if (!approvalFlairRequired) {
+      batchApprovalOptionsExpanded = false;
+    }
+
+    if (batchReviewToolbar) {
+      batchReviewToolbar.classList.toggle('hidden', !showBatchToolbar);
+      batchReviewToolbar.classList.toggle('batch-approve-expanded', batchApprovalOptionsExpanded);
+      batchReviewToolbar.classList.toggle('batch-deny-expanded', batchDenyOptionsExpanded);
+    }
+    document.body.classList.toggle('batch-review-floating-active', showBatchToolbar);
+    document.body.classList.toggle('batch-review-approve-expanded', showBatchToolbar && batchApprovalOptionsExpanded);
+    document.body.classList.toggle('batch-review-deny-expanded', showBatchToolbar && batchDenyOptionsExpanded);
+    if (batchSelectedCount) {
+      batchSelectedCount.textContent = `${selectedCount} selected`;
+    }
+    if (batchApprovalFlairWrap && batchApprovalFlairSelect) {
+      batchApprovalFlairWrap.classList.toggle('hidden', !approvalFlairRequired);
+      if (approvalFlairRequired) {
+        const selected = replaceSelectOptions(
+          batchApprovalFlairSelect,
+          approvalFlairChoices.map((choice) => ({ value: choice.templateId, label: choice.label })),
+          ''
+        );
+        if (batchApprovalFlairDraft && approvalFlairChoices.some((choice) => choice.templateId === batchApprovalFlairDraft)) {
+          batchApprovalFlairSelect.value = batchApprovalFlairDraft;
+        } else if (!selected && approvalFlairChoices[0]) {
+          batchApprovalFlairSelect.value = approvalFlairChoices[0].templateId;
+          batchApprovalFlairDraft = batchApprovalFlairSelect.value;
+        }
+      }
+    }
+
+    if (batchDenyReasonSelect) {
+      replaceSelectOptions(
+        batchDenyReasonSelect,
+        enabledReasons.map((reason) => ({ value: reason.id, label: reason.label })),
+        enabledReasons.length ? '-- Select denial reason --' : '-- No denial reasons configured --'
+      );
+      if (batchDenyReasonDraft && enabledReasons.some((reason) => reason.id === batchDenyReasonDraft)) {
+        batchDenyReasonSelect.value = batchDenyReasonDraft;
+      } else {
+        batchDenyReasonSelect.value = '';
+        batchDenyReasonDraft = '';
+      }
+      batchDenyReasonSelect.disabled = enabledReasons.length === 0;
+    }
+    if (batchDenyNotesInput && batchDenyNotesInput.value !== batchDenyNotesDraft) {
+      batchDenyNotesInput.value = batchDenyNotesDraft;
+    }
+
+    if (batchApproveBtn) {
+      batchApproveBtn.disabled = batchDenyOptionsExpanded
+        ? false
+        : selectedCount < 2 || !approvalsAllowed || (batchApprovalOptionsExpanded && approvalFlairRequired && !batchApprovalFlairDraft);
+      batchApproveBtn.title = !batchDenyOptionsExpanded && !approvalsAllowed ? buildApproveBlockedMessage() : '';
+      batchApproveBtn.textContent = batchDenyOptionsExpanded ? 'Back' : batchApprovalOptionsExpanded ? 'Confirm approval' : 'Approve';
+      batchApproveBtn.classList.toggle('btn-success', !batchDenyOptionsExpanded);
+      batchApproveBtn.classList.toggle('btn-secondary', batchDenyOptionsExpanded);
+    }
+    if (batchDenyBtn) {
+      batchDenyBtn.disabled = batchApprovalOptionsExpanded
+        ? false
+        : denyEligibleCount < 2 || enabledReasons.length === 0 || (batchDenyOptionsExpanded && !batchDenyReasonDraft);
+      batchDenyBtn.textContent = batchApprovalOptionsExpanded ? 'Back' : batchDenyOptionsExpanded ? 'Confirm denial' : 'Deny';
+      batchDenyBtn.title =
+        !batchApprovalOptionsExpanded && selectedCount >= 2 && denyEligibleCount < 2
+          ? 'Select at least two non-reopened requests to deny in batch.'
+          : '';
+      batchDenyBtn.classList.toggle('btn-danger', !batchApprovalOptionsExpanded);
+      batchDenyBtn.classList.toggle('btn-secondary', batchApprovalOptionsExpanded);
+    }
+    syncPendingSelectionCheckboxes();
+  }
+
+  function togglePendingSelection(verificationId, selected) {
+    const id = String(verificationId || '').trim();
+    if (!id) {
+      return;
+    }
+    if (selected) {
+      if (selectedPendingIds.size >= MAX_BATCH_REVIEW_ITEMS && !selectedPendingIds.has(id)) {
+        showToast(`Batch actions are limited to ${MAX_BATCH_REVIEW_ITEMS} requests.`, 'error');
+        syncPendingSelectionCheckboxes();
+        return;
+      }
+      selectedPendingIds.add(id);
+    } else {
+      selectedPendingIds.delete(id);
+    }
+    syncBatchToolbarState();
+  }
+
   function createPendingAgeBadge(submittedAt) {
     const ageHours = getPendingAgeHours(submittedAt);
     if (ageHours === null) {
@@ -2269,14 +2491,31 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     const isReReview = Boolean(item.parentVerificationId);
     const isResubmission = Boolean(item.isResubmission);
 
-    const viewerUsername = normalizeUsernameForCompare(state ? state.viewerUsername : '');
     const claimedByNormalized = normalizeUsernameForCompare(item.claimedBy);
     const isClaimed = Boolean(claimedByNormalized);
-    const isClaimedByOther = isClaimed && (!viewerUsername || claimedByNormalized !== viewerUsername);
+    const isClaimedByOther = isPendingItemClaimedByOther(item);
 
     const titleRow = document.createElement('div');
     titleRow.className = 'pending-title-row';
-    titleRow.appendChild(createPendingTitlePrimary(item));
+    const titleLeft = document.createElement('div');
+    titleLeft.className = 'pending-title-left';
+    if (!isClaimedByOther) {
+      const selectLabel = document.createElement('label');
+      selectLabel.className = 'pending-select-toggle';
+      const selectCheckbox = document.createElement('input');
+      selectCheckbox.type = 'checkbox';
+      selectCheckbox.value = String(item.id || '');
+      selectCheckbox.dataset.role = 'pending-select';
+      selectCheckbox.checked = selectedPendingIds.has(String(item.id || ''));
+      selectCheckbox.setAttribute('aria-label', `Select u/${item.username} for batch review`);
+      selectCheckbox.addEventListener('change', () => {
+        togglePendingSelection(item.id, selectCheckbox.checked);
+      });
+      selectLabel.appendChild(selectCheckbox);
+      titleLeft.appendChild(selectLabel);
+    }
+    titleLeft.appendChild(createPendingTitlePrimary(item));
+    titleRow.appendChild(titleLeft);
     const badgeRow = document.createElement('div');
     badgeRow.className = 'pending-badge-row';
     const accountDetails = normalizePendingAccountDetails(item);
@@ -2547,16 +2786,19 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     updatePendingSlaButtonStyles();
     setPendingSearchHintVisible(isShortNonEmptyPrefix(pendingSearchUserInput ? pendingSearchUserInput.value : ''));
     pendingList.innerHTML = '';
+    pruneSelectedPendingIds();
     const hasPendingItems = Boolean(state && Array.isArray(state.pending) && state.pending.length > 0);
     if (pendingLayout) {
       pendingLayout.dataset.mobilePriority = hasPendingItems ? 'list' : 'filters';
     }
     if (!hasPendingItems) {
+      syncBatchToolbarState();
       renderEmptyState(pendingList, 'No pending verifications', 'New verification requests will appear here.');
       return;
     }
 
-    const filtered = state.pending.filter(matchesPendingFilters).sort((left, right) => getPendingSortScore(left) - getPendingSortScore(right));
+    const filtered = getFilteredPendingItems();
+    syncBatchToolbarState();
     if (filtered.length === 0) {
       renderEmptyState(pendingList, 'No matching requests', 'Try adjusting the username filter or queue age range.');
       return;
@@ -2565,6 +2807,7 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     for (const item of filtered) {
       pendingList.appendChild(buildPendingCard(item));
     }
+    syncPendingSelectionCheckboxes();
   }
 
   function renderBlocked() {
@@ -4365,6 +4608,84 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     });
   }
 
+  function submitBatchApproval() {
+    if (batchDenyOptionsExpanded) {
+      batchDenyOptionsExpanded = false;
+      syncBatchToolbarState();
+      return;
+    }
+    const selectedItems = getSelectedPendingItems();
+    if (selectedItems.length < 2) {
+      showToast('Select at least two requests to approve in batch.', 'error');
+      return;
+    }
+    if (!canApprovePendingItems()) {
+      showToast(buildApproveBlockedMessage(), 'error');
+      return;
+    }
+    const approvalFlairChoices = getConfiguredApprovalFlairChoices();
+    const approvalFlairRequired = shouldBatchApprovalAskForFlair(approvalFlairChoices);
+    if (approvalFlairRequired && !batchApprovalOptionsExpanded) {
+      batchApprovalOptionsExpanded = true;
+      batchDenyOptionsExpanded = false;
+      syncBatchToolbarState();
+      if (batchApprovalFlairSelect) {
+        window.setTimeout(() => batchApprovalFlairSelect.focus(), 0);
+      }
+      return;
+    }
+    const selectedFlairTemplateId = approvalFlairRequired
+      ? batchApprovalFlairDraft || (batchApprovalFlairSelect ? batchApprovalFlairSelect.value : '') || approvalFlairChoices[0]?.templateId || ''
+      : '';
+    if (approvalFlairRequired && !selectedFlairTemplateId) {
+      showToast('Select an approval flair before approving selected requests.', 'error');
+      return;
+    }
+    postWithBusy({
+      type: 'batchReview',
+      action: 'approve',
+      verificationIds: selectedItems.map((item) => item.id),
+      selectedFlairTemplateId,
+    });
+  }
+
+  function submitBatchDenial() {
+    if (batchApprovalOptionsExpanded) {
+      batchApprovalOptionsExpanded = false;
+      syncBatchToolbarState();
+      return;
+    }
+    const selectedItems = getSelectedPendingItems().filter(isPendingItemDenyEligible);
+    if (selectedItems.length < 2) {
+      showToast('Select at least two non-reopened requests to deny in batch.', 'error');
+      return;
+    }
+    if (!getEnabledDenyReasons().length) {
+      showToast('No denial reasons are enabled in install settings.', 'error');
+      return;
+    }
+    if (!batchDenyOptionsExpanded) {
+      batchApprovalOptionsExpanded = false;
+      batchDenyOptionsExpanded = true;
+      syncBatchToolbarState();
+      if (batchDenyReasonSelect) {
+        window.setTimeout(() => batchDenyReasonSelect.focus(), 0);
+      }
+      return;
+    }
+    if (!batchDenyReasonDraft) {
+      showToast('Select a denial reason before denying selected requests.', 'error');
+      return;
+    }
+    postWithBusy({
+      type: 'batchReview',
+      action: 'deny',
+      verificationIds: selectedItems.map((item) => item.id),
+      reason: batchDenyReasonDraft,
+      moderatorNotes: batchDenyNotesDraft,
+    });
+  }
+
   if (bugReportLink) {
     bugReportLink.addEventListener('click', (event) => {
       event.preventDefault();
@@ -4412,6 +4733,34 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
         renderPending();
       });
     }
+  }
+
+  if (batchApprovalFlairSelect) {
+    batchApprovalFlairSelect.addEventListener('change', () => {
+      batchApprovalFlairDraft = batchApprovalFlairSelect.value;
+      syncBatchToolbarState();
+    });
+  }
+
+  if (batchApproveBtn) {
+    batchApproveBtn.addEventListener('click', submitBatchApproval);
+  }
+
+  if (batchDenyReasonSelect) {
+    batchDenyReasonSelect.addEventListener('change', () => {
+      batchDenyReasonDraft = batchDenyReasonSelect.value;
+      syncBatchToolbarState();
+    });
+  }
+
+  if (batchDenyNotesInput) {
+    batchDenyNotesInput.addEventListener('input', () => {
+      batchDenyNotesDraft = batchDenyNotesInput.value;
+    });
+  }
+
+  if (batchDenyBtn) {
+    batchDenyBtn.addEventListener('click', submitBatchDenial);
   }
 
   if (historyViewButtons.length) {


### PR DESCRIPTION
## Summary
- Add batch approve and deny actions for selected modqueue items.
- Reuse the existing single-item approval and denial paths so Redis writes, deletes, locks, audit logging, modmail, and mod notes stay centralized.
- Add a floating batch toolbar with compact mobile and desktop flows, including a second approval step when multiple approval flairs are enabled.
- Support shared denial reason and notes for batch denial, plus local state cleanup for multi-item removal.

## Testing
- Added unit coverage for batch ID normalization, toast summaries, and approve/deny batch outcomes.
- Verified the app with the existing test suite, typecheck, and production build.
- Performed UI logic validation for the batch toolbar state transitions and selection cleanup.