### PR TITLE
Improve instruction text helpers

### DIFF
--- a/webroot/hub-app.js
+++ b/webroot/hub-app.js
@@ -129,70 +129,75 @@ function createShell(root, inline) {
             <div data-el="action-row" class="row hub-action-dock"></div>
           </section>
 
-          <section data-el="developer-panel" class="hub-developer hidden">
-            <div class="hub-developer-copy">
-              <p class="hub-kicker">Developer Tools</p>
-              <h2>Global blocklist</h2>
-              <p class="meta">
-                This editor is read-only for app settings. Add or remove usernames here, then copy the updated value into the Devvit CLI.
-              </p>
-            </div>
-            <div class="hub-developer-stack">
-              <div>
-                <p class="hub-developer-label">Currently blocked</p>
-                <div data-el="developer-current-list" class="hub-developer-list"></div>
-                <p data-el="developer-empty" class="meta hidden">No usernames are currently blocked app-wide.</p>
+          <details data-el="developer-panel" class="hub-developer hidden">
+            <summary class="hub-developer-summary">
+              <span class="hub-kicker">Developer Tools</span>
+              <span class="hub-developer-summary-icon" aria-hidden="true"></span>
+            </summary>
+            <section class="hub-developer-content">
+              <div class="hub-developer-copy">
+                <h2>Global blocklist</h2>
+                <p class="meta">
+                  This editor is read-only for app settings. Add or remove usernames here, then copy the updated value into the Devvit CLI.
+                </p>
               </div>
-              <div>
-                <p class="hub-developer-label">Add one username</p>
-                <div class="hub-developer-input-row">
-                  <input
-                    data-el="developer-add-input"
-                    class="hub-developer-input"
-                    type="text"
-                    placeholder="u/example_user"
-                    autocomplete="off"
+              <div class="hub-developer-stack">
+                <div>
+                  <p class="hub-developer-label">Currently blocked</p>
+                  <div data-el="developer-current-list" class="hub-developer-list"></div>
+                  <p data-el="developer-empty" class="meta hidden">No usernames are currently blocked app-wide.</p>
+                </div>
+                <div>
+                  <p class="hub-developer-label">Add one username</p>
+                  <div class="hub-developer-input-row">
+                    <input
+                      data-el="developer-add-input"
+                      class="hub-developer-input"
+                      type="text"
+                      placeholder="u/example_user"
+                      autocomplete="off"
+                      spellcheck="false"
+                    />
+                    <button data-el="developer-add-btn" class="btn-secondary" type="button">Add</button>
+                  </div>
+                </div>
+                <div>
+                  <p class="hub-developer-label">Add multiple usernames</p>
+                  <textarea
+                    data-el="developer-bulk-input"
+                    class="hub-developer-textarea"
+                    rows="4"
+                    placeholder="u/test_user1&#10;test_user2, test_user3"
                     spellcheck="false"
-                  />
-                  <button data-el="developer-add-btn" class="btn-secondary" type="button">Add</button>
+                  ></textarea>
+                  <div class="row">
+                    <button data-el="developer-bulk-btn" class="btn-secondary" type="button">Add Pasted List</button>
+                    <button data-el="developer-reset-btn" class="btn-secondary" type="button">Reset to Current</button>
+                  </div>
+                </div>
+                <div data-el="developer-invalid" class="hub-developer-warning hidden"></div>
+                <p data-el="developer-draft-status" class="hub-developer-status"></p>
+                <div>
+                  <p class="hub-developer-label">Commands to paste into Devvit CLI</p>
+                  <textarea
+                    data-el="developer-canonical-output"
+                    class="hub-developer-textarea hub-developer-output"
+                    rows="10"
+                    readonly
+                  ></textarea>
+                  <div class="row">
+                    <button data-el="developer-copy-btn" class="btn-primary" type="button">Copy Terminal Commands</button>
+                  </div>
+                </div>
+                <div class="hub-developer-instructions">
+                  <p class="hub-developer-label">Apply the change</p>
+                  <p class="meta">1. Paste the copied commands into your terminal.</p>
+                  <p class="meta">2. The populated blocklist chunks are updated first, and the final line updates the active chunk count.</p>
+                  <p class="meta">3. Refresh the app to confirm the updated list.</p>
                 </div>
               </div>
-              <div>
-                <p class="hub-developer-label">Add multiple usernames</p>
-                <textarea
-                  data-el="developer-bulk-input"
-                  class="hub-developer-textarea"
-                  rows="4"
-                  placeholder="u/test_user1&#10;test_user2, test_user3"
-                  spellcheck="false"
-                ></textarea>
-                <div class="row">
-                  <button data-el="developer-bulk-btn" class="btn-secondary" type="button">Add Pasted List</button>
-                  <button data-el="developer-reset-btn" class="btn-secondary" type="button">Reset to Current</button>
-                </div>
-              </div>
-              <div data-el="developer-invalid" class="hub-developer-warning hidden"></div>
-              <p data-el="developer-draft-status" class="hub-developer-status"></p>
-              <div>
-                <p class="hub-developer-label">Commands to paste into Devvit CLI</p>
-                <textarea
-                  data-el="developer-canonical-output"
-                  class="hub-developer-textarea hub-developer-output"
-                  rows="10"
-                  readonly
-                ></textarea>
-                <div class="row">
-                  <button data-el="developer-copy-btn" class="btn-primary" type="button">Copy Terminal Commands</button>
-                </div>
-              </div>
-              <div class="hub-developer-instructions">
-                <p class="hub-developer-label">Apply the change</p>
-                <p class="meta">1. Paste the copied commands into your terminal.</p>
-                <p class="meta">2. The populated blocklist chunks are updated first, and the final line updates the active chunk count.</p>
-                <p class="meta">3. Refresh the app to confirm the updated list.</p>
-              </div>
-            </div>
-          </section>
+            </section>
+          </details>
 
           <footer data-el="legal-links" class="legal-links hidden"></footer>
         </section>
@@ -527,6 +532,14 @@ function renderMarkdown(value) {
       closeList();
       const level = Math.min(6, headingMatch[1].length + 2);
       html.push(`<h${level}>${renderInlineMarkdown(headingMatch[2])}</h${level}>`);
+      continue;
+    }
+
+    const quoteMatch = line.match(/^>\s?(.*)$/);
+    if (quoteMatch) {
+      flushParagraph();
+      closeList();
+      html.push(`<blockquote><p>${renderInlineMarkdown(quoteMatch[1])}</p></blockquote>`);
       continue;
     }
 
@@ -928,19 +941,17 @@ export function mountHub(options = {}) {
     if (!refs.photoInstructionsBody || !refs.photoInstructionsScrollShell) {
       return;
     }
-    if (shouldUseAndroidPhotoInstructionsStep()) {
-      refs.photoInstructionsScrollShell.dataset.scrollOverflow = 'false';
-      refs.photoInstructionsScrollShell.dataset.scrollBottom = 'true';
-      if (refs.photoInstructionsScrollHint) {
-        refs.photoInstructionsScrollHint.classList.add('hidden');
-      }
+    const scrollTarget = shouldUseAndroidPhotoInstructionsStep()
+      ? refs.photoInstructionsModal
+      : refs.photoInstructionsBody;
+    if (!scrollTarget) {
       return;
     }
-    const overflow = refs.photoInstructionsBody.scrollHeight - refs.photoInstructionsBody.clientHeight > 8;
+    const overflow = scrollTarget.scrollHeight - scrollTarget.clientHeight > 8;
     const atBottom =
-      refs.photoInstructionsBody.scrollTop + refs.photoInstructionsBody.clientHeight >=
-      refs.photoInstructionsBody.scrollHeight - 6;
-    const nearTop = refs.photoInstructionsBody.scrollTop <= 10;
+      scrollTarget.scrollTop + scrollTarget.clientHeight >=
+      scrollTarget.scrollHeight - 6;
+    const nearTop = scrollTarget.scrollTop <= 10;
     refs.photoInstructionsScrollShell.dataset.scrollOverflow = overflow ? 'true' : 'false';
     refs.photoInstructionsScrollShell.dataset.scrollBottom = atBottom ? 'true' : 'false';
     if (refs.photoInstructionsScrollHint) {
@@ -989,6 +1000,12 @@ export function mountHub(options = {}) {
 
   if (refs.photoInstructionsBody) {
     refs.photoInstructionsBody.addEventListener('scroll', () => {
+      updatePhotoInstructionsScrollAffordance();
+    });
+  }
+
+  if (refs.photoInstructionsModal) {
+    refs.photoInstructionsModal.addEventListener('scroll', () => {
       updatePhotoInstructionsScrollAffordance();
     });
   }

--- a/webroot/hub-ui.css
+++ b/webroot/hub-ui.css
@@ -486,6 +486,57 @@ button:not(:disabled):hover {
   z-index: 1;
 }
 
+.hub-developer-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 44px;
+  padding: 11px 13px;
+  border: 1px solid color-mix(in srgb, var(--line) 84%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--card) 78%, var(--bg) 22%);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.hub-developer-summary::-webkit-details-marker {
+  display: none;
+}
+
+.hub-developer-summary:hover,
+.hub-developer-summary:focus-visible {
+  border-color: color-mix(in srgb, var(--primary) 32%, var(--line) 68%);
+}
+
+.hub-developer-summary:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary) 42%, transparent);
+  outline-offset: 3px;
+}
+
+.hub-developer-summary .hub-kicker {
+  margin: 0;
+}
+
+.hub-developer-summary-icon {
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  color: color-mix(in srgb, var(--muted) 74%, var(--text) 26%);
+  transform: rotate(45deg);
+  transition: transform 140ms ease;
+}
+
+.hub-developer[open] .hub-developer-summary-icon {
+  transform: rotate(225deg);
+}
+
+.hub-developer-content {
+  margin-top: 14px;
+}
+
 .hub-developer-copy {
   display: flex;
   flex-direction: column;
@@ -770,9 +821,13 @@ button:not(:disabled):hover {
 }
 
 [data-el="photo-instructions-modal"].hub-photo-instructions-step .hub-scroll-shell::before,
-[data-el="photo-instructions-modal"].hub-photo-instructions-step .hub-scroll-shell::after,
-[data-el="photo-instructions-modal"].hub-photo-instructions-step .hub-scroll-hint {
+[data-el="photo-instructions-modal"].hub-photo-instructions-step .hub-scroll-shell::after {
   display: none;
+}
+
+[data-el="photo-instructions-modal"].hub-photo-instructions-step .hub-scroll-hint {
+  position: fixed;
+  bottom: calc(18px + env(safe-area-inset-bottom, 0px));
 }
 
 [data-el="photo-instructions-modal"].hub-photo-instructions-step .hub-modal-copy {
@@ -894,10 +949,15 @@ button:not(:disabled):hover {
 
 .hub-scroll-hint {
   position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   left: 50%;
   bottom: 6px;
   z-index: 2;
   transform: translateX(-50%);
+  width: max-content;
+  max-width: calc(100vw - 48px);
   padding: 5px 10px;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, var(--primary) 44%, var(--line) 56%);
@@ -905,8 +965,11 @@ button:not(:disabled):hover {
   color: color-mix(in srgb, var(--primary) 78%, var(--text) 22%);
   font-size: 0.74rem;
   font-weight: 800;
+  line-height: 1.25;
   letter-spacing: 0.1em;
+  text-align: center;
   text-transform: uppercase;
+  white-space: nowrap;
   pointer-events: none;
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--card) 84%, transparent),
@@ -944,7 +1007,8 @@ button:not(:disabled):hover {
 
 .markdown-body p,
 .markdown-body ul,
-.markdown-body ol {
+.markdown-body ol,
+.markdown-body blockquote {
   margin: 0 0 12px;
 }
 
@@ -955,6 +1019,18 @@ button:not(:disabled):hover {
 
 .markdown-body li + li {
   margin-top: 6px;
+}
+
+.markdown-body blockquote {
+  padding: 8px 12px;
+  border-left: 3px solid color-mix(in srgb, var(--primary) 58%, var(--line) 42%);
+  border-radius: 0 8px 8px 0;
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  color: color-mix(in srgb, var(--text) 88%, var(--muted) 12%);
+}
+
+.markdown-body blockquote p {
+  margin: 0;
 }
 
 .markdown-body code {

--- a/webroot/mod-panel.css
+++ b/webroot/mod-panel.css
@@ -864,6 +864,61 @@ textarea {
 
 .textarea-helper-btn-italic {
   font-style: italic;
+  text-transform: lowercase;
+}
+
+.textarea-helper-tip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid color-mix(in srgb, var(--panel-border) 56%, transparent);
+  border-radius: 999px;
+  color: color-mix(in srgb, var(--muted) 86%, var(--text) 14%);
+  background: color-mix(in srgb, var(--panel-surface-soft) 82%, black 18%);
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1;
+  cursor: help;
+}
+
+.textarea-helper-tip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  width: min(290px, calc(100vw - 48px));
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--panel-border-strong) 72%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel-surface-strong) 94%, black 6%);
+  color: var(--text);
+  box-shadow: var(--card-shadow-soft);
+  font-size: 0.76rem;
+  font-weight: 600;
+  line-height: 1.35;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translate(-50%, 4px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+
+.textarea-helper-tip:hover::after,
+.textarea-helper-tip:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.textarea-helper-tip:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--primary) 64%, var(--panel-border) 36%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-soft) 54%, transparent);
 }
 
 .textarea-helper-select {

--- a/webroot/mod-panel.html
+++ b/webroot/mod-panel.html
@@ -525,9 +525,9 @@
                     <p><em>Italic:</em> <code>*text*</code></p>
                     <p><strong><em>Bold italic:</em></strong> <code>***text***</code></p>
                     <p><strong>Link:</strong> <code>[text](https://example.com)</code></p>
-                    <p><strong>Inline code:</strong> <code>`text`</code></p>
+                    <p><strong>Quote:</strong> <code>&gt; text</code></p>
                     <p><strong>Caps helper:</strong> converts selected text to uppercase. Selected placeholders become <code>{{caps:name}}</code>.</p>
-                    <p><strong>Heading:</strong> <code>## Heading</code></p>
+                    <p><strong>Headings:</strong> <code># Heading</code>, <code>## Heading</code>, <code>### Heading</code></p>
                     <p><strong>Line break:</strong> press Enter twice</p>
                     <p><strong>Bullet list:</strong><br><code>- Item</code><br><code>- Item</code></p>
                     <p><strong>Numbered list:</strong><br><code>1. Item</code><br><code>2. Item</code></p>
@@ -967,6 +967,24 @@
         <div class="row">
           <button id="approve-banned-cancel-btn" class="btn btn-secondary" type="button">No</button>
           <button id="approve-banned-confirm-btn" class="btn btn-primary" type="button">Yes</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="textarea-link-modal" class="dialog-modal hidden">
+      <div class="dialog-card">
+        <h3>Insert link</h3>
+        <div class="field-stack">
+          <label class="field-label" for="textarea-link-text">Link text</label>
+          <input id="textarea-link-text" class="field-input" type="text" placeholder="Link text" />
+        </div>
+        <div class="field-stack">
+          <label class="field-label" for="textarea-link-url">URL</label>
+          <input id="textarea-link-url" class="field-input" type="url" placeholder="https://example.com" />
+        </div>
+        <div class="row">
+          <button id="textarea-link-cancel-btn" class="btn btn-secondary" type="button">Cancel</button>
+          <button id="textarea-link-insert-btn" class="btn btn-primary" type="button">Insert Link</button>
         </div>
       </div>
     </div>

--- a/webroot/mod-panel.js
+++ b/webroot/mod-panel.js
@@ -216,6 +216,11 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   const approveBannedModal = document.getElementById('approve-banned-modal');
   const approveBannedCancelBtn = document.getElementById('approve-banned-cancel-btn');
   const approveBannedConfirmBtn = document.getElementById('approve-banned-confirm-btn');
+  const textareaLinkModal = document.getElementById('textarea-link-modal');
+  const textareaLinkTextInput = document.getElementById('textarea-link-text');
+  const textareaLinkUrlInput = document.getElementById('textarea-link-url');
+  const textareaLinkCancelBtn = document.getElementById('textarea-link-cancel-btn');
+  const textareaLinkInsertBtn = document.getElementById('textarea-link-insert-btn');
   const bugReportLink = document.getElementById('bug-report-link');
   const externalNavigationLinks = Array.from(document.querySelectorAll('[data-open-external-url]'));
 
@@ -223,10 +228,11 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     'bold',
     'italic',
     'link',
-    'code',
+    'quote',
     'caps',
-    'heading',
-    'line-break',
+    'heading-1',
+    'heading-2',
+    'heading-3',
     'bullet-list',
     'numbered-list',
   ];
@@ -244,14 +250,22 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
   const REMOVAL_TEXTAREA_PLACEHOLDERS = [...APPROVAL_TEXTAREA_PLACEHOLDERS, '{{reason}}'];
   const TEXTAREA_HELPER_ACTION_LABELS = {
     bold: { label: 'B', ariaLabel: 'Insert bold Markdown', title: 'Bold' },
-    italic: { label: 'I', ariaLabel: 'Insert italic Markdown', title: 'Italic', className: 'textarea-helper-btn-italic' },
+    italic: { label: 'i', ariaLabel: 'Insert italic Markdown', title: 'Italic', className: 'textarea-helper-btn-italic' },
     link: { label: 'Link', ariaLabel: 'Insert Markdown link', title: 'Link' },
-    code: { label: 'Code', ariaLabel: 'Insert inline code Markdown', title: 'Inline code' },
+    quote: { label: 'Quote', ariaLabel: 'Insert quote Markdown', title: 'Quote' },
     caps: { label: 'Caps', ariaLabel: 'Convert selected text to uppercase', title: 'Uppercase selected text' },
-    heading: { label: 'H2', ariaLabel: 'Insert heading Markdown', title: 'Heading' },
-    'line-break': { label: 'Break', ariaLabel: 'Insert paragraph break', title: 'Line break' },
+    'heading-1': { label: 'H1', ariaLabel: 'Insert H1 Markdown heading', title: 'Heading 1' },
+    'heading-2': { label: 'H2', ariaLabel: 'Insert H2 Markdown heading', title: 'Heading 2' },
+    'heading-3': { label: 'H3', ariaLabel: 'Insert H3 Markdown heading', title: 'Heading 3' },
     'bullet-list': { label: 'List', ariaLabel: 'Insert bullet list Markdown', title: 'Bullet list' },
     'numbered-list': { label: '1. List', ariaLabel: 'Insert numbered list Markdown', title: 'Numbered list' },
+  };
+  const TEXTAREA_HELPER_TIP =
+    'Press a button to insert formatting. To format text that is already there, select the text first, then press the button.';
+  const TEXTAREA_HEADING_MARKERS = {
+    'heading-1': '#',
+    'heading-2': '##',
+    'heading-3': '###',
   };
   const TEXTAREA_HELPER_CONFIGS = {
     'photo-instructions': {
@@ -311,6 +325,7 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     },
   };
   const textareaHelperSelections = new WeakMap();
+  let textareaLinkTarget = null;
 
   let state = null;
   let stateInitialized = false;
@@ -494,6 +509,17 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     return select;
   }
 
+  function createTextareaHelperTip() {
+    const tip = document.createElement('span');
+    tip.className = 'textarea-helper-tip';
+    tip.tabIndex = 0;
+    tip.dataset.tooltip = TEXTAREA_HELPER_TIP;
+    tip.setAttribute('aria-label', TEXTAREA_HELPER_TIP);
+    tip.title = TEXTAREA_HELPER_TIP;
+    tip.textContent = '?';
+    return tip;
+  }
+
   function renderTextareaHelperToolbar(toolbar, config) {
     toolbar.textContent = '';
     for (const action of config.actions) {
@@ -502,6 +528,7 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
         toolbar.appendChild(button);
       }
     }
+    toolbar.appendChild(createTextareaHelperTip());
     if (config.placeholders.length) {
       toolbar.appendChild(createTextareaPlaceholderSelect(config));
     }
@@ -580,18 +607,17 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     return range;
   }
 
-  function replaceTextareaSelection(textarea, replacement, selectionStartOffset, selectionEndOffset) {
+  function replaceTextareaRange(textarea, start, end, replacement, selectionStartOffset, selectionEndOffset) {
     const value = String(textarea.value || '');
     const scrollState = captureTextareaScrollState(textarea);
-    const range = getTextareaSelectionRange(textarea);
-    const start = Math.min(range.start, range.end);
-    const end = Math.max(range.start, range.end);
-    const nextValue = `${value.slice(0, start)}${replacement}${value.slice(end)}`;
+    const boundedStart = Math.max(0, Math.min(start, value.length));
+    const boundedEnd = Math.max(boundedStart, Math.min(end, value.length));
+    const nextValue = `${value.slice(0, boundedStart)}${replacement}${value.slice(boundedEnd)}`;
     textarea.value = nextValue;
     textarea.focus();
 
-    const cursorStart = start + selectionStartOffset;
-    const cursorEnd = start + selectionEndOffset;
+    const cursorStart = boundedStart + selectionStartOffset;
+    const cursorEnd = boundedStart + selectionEndOffset;
     try {
       textarea.setSelectionRange(cursorStart, cursorEnd);
     } catch {
@@ -603,6 +629,13 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     });
     rememberTextareaSelection(textarea);
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function replaceTextareaSelection(textarea, replacement, selectionStartOffset, selectionEndOffset) {
+    const range = getTextareaSelectionRange(textarea);
+    const start = Math.min(range.start, range.end);
+    const end = Math.max(range.start, range.end);
+    replaceTextareaRange(textarea, start, end, replacement, selectionStartOffset, selectionEndOffset);
   }
 
   function wrapTextareaSelection(textarea, prefix, suffix, fallbackText) {
@@ -668,13 +701,119 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
     replaceTextareaSelection(textarea, bounded.text, selectStart, selectEnd);
   }
 
-  function insertTextareaLineBreak(textarea) {
+  function insertTextareaQuote(textarea) {
+    insertTextareaLinePrefix(textarea, '> ', 'Quote', (line) => (
+      line.startsWith('>') ? line : `> ${line}`
+    ));
+  }
+
+  function insertTextareaLinePrefix(textarea, prefix, fallbackText, formatLine) {
     const value = String(textarea.value || '');
+    if (!value) {
+      const replacement = `${prefix}${fallbackText}`;
+      replaceTextareaSelection(textarea, replacement, prefix.length, replacement.length);
+      return;
+    }
+
     const range = getTextareaSelectionRange(textarea);
-    const start = Math.min(range.start, range.end);
-    const before = value.slice(0, start);
-    const breakText = before && !before.endsWith('\n') ? '\n\n' : '\n';
-    replaceTextareaSelection(textarea, breakText, breakText.length, breakText.length);
+    const selectionStart = Math.min(range.start, range.end);
+    const selectionEnd = Math.max(range.start, range.end);
+    const startLineSearchIndex = Math.max(0, selectionStart - 1);
+    const lineStart = value.lastIndexOf('\n', startLineSearchIndex) + 1;
+    const endLineSearchIndex = selectionEnd > selectionStart
+      ? Math.max(selectionStart, selectionEnd - 1)
+      : selectionEnd;
+    const nextLineBreakIndex = value.indexOf('\n', endLineSearchIndex);
+    const lineEnd = nextLineBreakIndex === -1 ? value.length : nextLineBreakIndex;
+    const selectedLines = value.slice(lineStart, lineEnd);
+    const nextLines = selectedLines
+      ? selectedLines
+        .split('\n')
+        .map((line) => (line ? formatLine(line) : line))
+        .join('\n')
+      : `${prefix}${fallbackText}`;
+    const firstLine = selectedLines.split('\n')[0] || '';
+    const formattedFirstLine = firstLine ? formatLine(firstLine) : `${prefix}${fallbackText}`;
+    const prefixOffset = Math.max(0, formattedFirstLine.length - firstLine.length);
+    const hasSelection = selectionEnd > selectionStart;
+    const cursorOffset = selectedLines
+      ? (hasSelection ? nextLines.length : selectionStart - lineStart + prefixOffset)
+      : prefix.length;
+    const selectionEndOffset = selectedLines ? cursorOffset : nextLines.length;
+    replaceTextareaRange(textarea, lineStart, lineEnd, nextLines, cursorOffset, selectionEndOffset);
+  }
+
+  function insertTextareaHeading(textarea, marker) {
+    insertTextareaLinePrefix(textarea, `${marker} `, 'Heading', (line) => {
+      const unheadedLine = line.replace(/^#{1,3}\s+/, '');
+      return `${marker} ${unheadedLine}`;
+    });
+  }
+
+  function normalizeTextareaLinkUrl(value) {
+    const trimmed = String(value || '').trim();
+    if (!trimmed) {
+      return '';
+    }
+    const candidate = /^[a-z][a-z0-9+.-]*:/i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    try {
+      const parsed = new URL(candidate);
+      return parsed.protocol === 'https:' || parsed.protocol === 'http:' ? parsed.toString() : '';
+    } catch {
+      return '';
+    }
+  }
+
+  function openTextareaLinkDialog(textarea) {
+    if (
+      !textareaLinkModal ||
+      !textareaLinkTextInput ||
+      !textareaLinkUrlInput ||
+      !textareaLinkInsertBtn
+    ) {
+      const selectedText = selectedTextareaText(textarea);
+      const label = selectedText || 'text';
+      const replacement = `[${label}](https://example.com)`;
+      replaceTextareaSelection(textarea, replacement, replacement.length, replacement.length);
+      return;
+    }
+    textareaLinkTarget = textarea;
+    const selectedText = selectedTextareaText(textarea).replace(/\s+/g, ' ').trim();
+    textareaLinkTextInput.value = selectedText;
+    textareaLinkUrlInput.value = '';
+    textareaLinkModal.classList.remove('hidden');
+    window.requestAnimationFrame(() => {
+      (selectedText ? textareaLinkUrlInput : textareaLinkTextInput).focus();
+    });
+  }
+
+  function closeTextareaLinkDialog() {
+    if (textareaLinkModal) {
+      textareaLinkModal.classList.add('hidden');
+    }
+    textareaLinkTarget = null;
+  }
+
+  function insertTextareaLinkFromDialog() {
+    if (!textareaLinkTarget || !textareaLinkTextInput || !textareaLinkUrlInput) {
+      closeTextareaLinkDialog();
+      return;
+    }
+    const label = String(textareaLinkTextInput.value || '').trim();
+    const url = normalizeTextareaLinkUrl(textareaLinkUrlInput.value);
+    if (!label) {
+      showToast('Enter link text before inserting the link.', 'error');
+      textareaLinkTextInput.focus();
+      return;
+    }
+    if (!url) {
+      showToast('Enter a valid http or https URL.', 'error');
+      textareaLinkUrlInput.focus();
+      return;
+    }
+    const replacement = `[${label.replaceAll('[', '\\[').replaceAll(']', '\\]')}](${url})`;
+    replaceTextareaSelection(textareaLinkTarget, replacement, replacement.length, replacement.length);
+    closeTextareaLinkDialog();
   }
 
   function insertTextareaHelperAction(textarea, action) {
@@ -686,8 +825,8 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       wrapTextareaSelection(textarea, '*', '*', 'text');
       return;
     }
-    if (action === 'code') {
-      wrapTextareaSelection(textarea, '`', '`', 'text');
+    if (action === 'quote') {
+      insertTextareaQuote(textarea);
       return;
     }
     if (action === 'caps') {
@@ -706,25 +845,11 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       return;
     }
     if (action === 'link') {
-      const selectedText = selectedTextareaText(textarea);
-      const label = selectedText || 'text';
-      const replacement = `[${label}](https://example.com)`;
-      const labelStart = 1;
-      const labelEnd = 1 + label.length;
-      replaceTextareaSelection(
-        textarea,
-        replacement,
-        selectedText ? replacement.length : labelStart,
-        selectedText ? replacement.length : labelEnd
-      );
+      openTextareaLinkDialog(textarea);
       return;
     }
-    if (action === 'heading') {
-      insertTextareaBlock(textarea, 'Heading', (line) => `## ${line}`);
-      return;
-    }
-    if (action === 'line-break') {
-      insertTextareaLineBreak(textarea);
+    if (action === 'heading-1' || action === 'heading-2' || action === 'heading-3') {
+      insertTextareaHeading(textarea, TEXTAREA_HEADING_MARKERS[action]);
       return;
     }
     if (action === 'bullet-list') {
@@ -5674,6 +5799,33 @@ import { BUG_REPORT_URL, MODERATOR_QUICK_START_URL } from './app-config.js';
       }
     });
   }
+  if (textareaLinkCancelBtn) {
+    textareaLinkCancelBtn.addEventListener('click', closeTextareaLinkDialog);
+  }
+  if (textareaLinkInsertBtn) {
+    textareaLinkInsertBtn.addEventListener('click', insertTextareaLinkFromDialog);
+  }
+  if (textareaLinkModal) {
+    textareaLinkModal.addEventListener('click', (event) => {
+      if (event.target === textareaLinkModal) {
+        closeTextareaLinkDialog();
+      }
+    });
+  }
+  [textareaLinkTextInput, textareaLinkUrlInput].forEach((input) => {
+    if (!input) {
+      return;
+    }
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        insertTextareaLinkFromDialog();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        closeTextareaLinkDialog();
+      }
+    });
+  });
 
   for (const btn of settingsTabButtons) {
     btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Add richer textarea helper controls for photo instructions and template bodies
- Add username/today/caps helpers, line-aware quote and heading formatting, and link insertion dialog
- Add Portuguese (Brazil) instructions slot, disabled dirty-state save button, photo instructions scroll affordance fixes, and collapsible developer tools

## Validation
- npm run check
- npm run build
- npm test

## Notes
- UI-only changes in webroot; no Devvit config, server, permissions, storage, modmail workflow, approval, denial, or removal logic changed.