### PR TITLE
Treat GOAWAY / cancelled / gateway-retry-exhausted gRPC errors as transient

### DIFF
--- a/src/core/moderator-access.ts
+++ b/src/core/moderator-access.ts
@@ -235,42 +235,53 @@ export async function getCurrentModeratorPermissionSnapshot(
     };
   }
 
-  try {
-    const currentUser = viewerIdentity.user;
-    if (!currentUser) {
-      const cachedPermissions = await getCachedModeratorPermissions(context, username);
-      return {
-        permissions: cachedPermissions,
-        state: cachedPermissions.length > 0 ? 'cached' : 'unknown',
-      };
-    }
-    const permissions = normalizeModeratorPermissions(
-      await currentUser.getModPermissionsForSubreddit(sanitizedSubreddit)
-    );
-    await cacheModeratorPermissions(context, username, permissions);
-    return {
-      permissions,
-      state: 'confirmed',
-    };
-  } catch (error) {
+  const currentUser = viewerIdentity.user;
+  if (!currentUser) {
     const cachedPermissions = await getCachedModeratorPermissions(context, username);
-    if (cachedPermissions.length > 0) {
-      return {
-        permissions: cachedPermissions,
-        state: 'cached',
-      };
-    }
-    await logModeratorLookupFailureWithCooldown(
-      context,
-      'permissions',
-      username,
-      `Moderator permission lookup failed for r/${sanitizedSubreddit} u/${maskUsernameForLog(username)}: ${errorText(error)}`
-    );
     return {
-      permissions: [],
-      state: 'unknown',
+      permissions: cachedPermissions,
+      state: cachedPermissions.length > 0 ? 'cached' : 'unknown',
     };
   }
+
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const permissions = normalizeModeratorPermissions(
+        await currentUser.getModPermissionsForSubreddit(sanitizedSubreddit)
+      );
+      await cacheModeratorPermissions(context, username, permissions);
+      return {
+        permissions,
+        state: 'confirmed',
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt < 1 && looksLikeTransientRedditTransportError(errorText(error))) {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        continue;
+      }
+      break;
+    }
+  }
+
+  const cachedPermissions = await getCachedModeratorPermissions(context, username);
+  if (cachedPermissions.length > 0) {
+    return {
+      permissions: cachedPermissions,
+      state: 'cached',
+    };
+  }
+  await logModeratorLookupFailureWithCooldown(
+    context,
+    'permissions',
+    username,
+    `Moderator permission lookup failed for r/${sanitizedSubreddit} u/${maskUsernameForLog(username)}: ${errorText(lastError)}`
+  );
+  return {
+    permissions: [],
+    state: 'unknown',
+  };
 }
 
 export async function assertCanAccessModeratorSettingsTab(

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -260,7 +260,12 @@ export function looksLikeTransientRedditTransportError(message: string): boolean
     normalized.includes('timeout') ||
     normalized.includes('socket hang up') ||
     normalized.includes('econnreset') ||
-    normalized.includes('connection reset')
+    normalized.includes('connection reset') ||
+    normalized.includes('goaway') ||
+    normalized.includes('graceful shutdown') ||
+    normalized.includes('call cancelled') ||
+    /^1 cancelled\b/.test(normalized) ||
+    /\bfailed to get \d{3} response after \d+ attempts?\b/.test(normalized)
   );
 }
 


### PR DESCRIPTION
## Summary

Two coupled issues in production logs (r/MassiveCock, r/ThickDick over 2026-05-29 → 2026-05-31):

- `Moderator permission lookup failed` and `Viewer flair snapshot lookup failed` warnings firing on transient Reddit gateway blips: HTTP/2 `GOAWAY ... graceful shutdown`, gRPC `1 CANCELLED: Call cancelled`, and `failed to get 200 response after 4 attempts`. These weren't matched by `looksLikeTransientRedditTransportError`, so they bypassed the retry/silence path the other lookups use.
- `Fatal Unhandled Promise rejected: 16 UNAUTHENTICATED: invalid JWT token` from Devvit's own log-stream gRPC client (`console._ForwardingConsole_send2 → LogStream`). Each fatal in the dump immediately follows one of the warnings above — the act of logging tripped the platform crash. Not patchable on our side, but reducing the warning volume should reduce frequency.

Changes:
- `src/core/normalize.ts`: extend `looksLikeTransientRedditTransportError` to match `goaway`, `graceful shutdown`, `call cancelled`, `1 cancelled …`, and `failed to get NNN response after N attempts`.
- `src/core/moderator-access.ts`: `getCurrentModeratorPermissionSnapshot` now retries once on transient transport errors before falling back to cache/unknown — same pattern viewer-identity and flair already use.

## Test plan

- [x] `npm run check`
- [x] `npm test` (176 pass)
- [x] `npm run build`
- [ ] After deploy: confirm `Moderator permission lookup failed` / `Viewer flair snapshot lookup failed` log volume drops and JWT fatals subside on the two production subs

🤖 Generated with [Claude Code](https://claude.com/claude-code)