### PR TITLE
Update Devvit CLI and app packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@devvit/public-api": "0.13.0",
         "@types/node": "^22.10.5",
-        "devvit": "0.13.0",
+        "devvit": "0.13.4",
         "typescript": "5.8.3"
       },
       "engines": {
@@ -180,15 +180,15 @@
       }
     },
     "node_modules/@devvit/build-pack": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@devvit/build-pack/-/build-pack-0.13.0.tgz",
-      "integrity": "sha512-i4ZK/Js9uZ0yYXarnTVmK5/Ad2yRXKE97nvUuEv/Hb3eQ7PGqi+jAsOMmcW0m1naugt5pKq6iDc71yAtAUIAeg==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/build-pack/-/build-pack-0.13.4.tgz",
+      "integrity": "sha512-aWd1FlnGT7Mk/pTEJvnwWtfdXzsONp+6qIi4F0dtMoOab3wQcSQCRnrhWmn4C50xy3Ff8mKk0z9GaY4ojOGY9w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@devvit/payments": "0.13.0",
-        "@devvit/protos": "0.13.0",
-        "@devvit/shared-types": "0.13.0",
+        "@devvit/payments": "0.13.4",
+        "@devvit/protos": "0.13.4",
+        "@devvit/shared-types": "0.13.4",
         "@types/node": "20.14.12",
         "esbuild": "0.25.9",
         "rxjs": "7.8.1",
@@ -198,6 +198,112 @@
       "peerDependencies": {
         "@devvit/server": "*",
         "@devvit/shared": "*"
+      }
+    },
+    "node_modules/@devvit/build-pack/node_modules/@devvit/metrics": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/metrics/-/metrics-0.13.4.tgz",
+      "integrity": "sha512-0CCfLcX7BxnPoJqMpsiSkxMr4yP7YzerSncOrW9cC4M44eqwRCUOmBq8VET6wtx5fyX4asQJwAYhiwTbBpcCZA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/build-pack/node_modules/@devvit/payments": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/payments/-/payments-0.13.4.tgz",
+      "integrity": "sha512-ovZXc90eg1mFPkU0ZIzm6z+mcsKfJgAPa78y9ozf6oHMABT9ioATd+V9aQ0oiLb/xDgi1OLhZrpwvBhs77qJ0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "@devvit/public-api": "0.13.4",
+        "@devvit/server": "0.13.4",
+        "@devvit/shared-types": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/build-pack/node_modules/@devvit/payments/node_modules/@devvit/server": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/server/-/server-0.13.4.tgz",
+      "integrity": "sha512-G9ypVImHyyCVL7wGpopvTQSlzNalQtYh7lOG27oZdnUdhCMDBVn7hpDw02/NHRR+4sfE1wKKIHItVifZ8c382A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "@devvit/public-api": "0.13.4",
+        "@devvit/shared": "0.13.4",
+        "@devvit/shared-types": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/build-pack/node_modules/@devvit/payments/node_modules/@devvit/shared": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/shared/-/shared-0.13.4.tgz",
+      "integrity": "sha512-sZULTST2veBEXOfkMwtQwSTjntvOMoCf10qGJgdeB2jNwTwJ2XIIwJCF3ppeA3ATGKIb/kh8OVwYGt/p2j30nA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "@devvit/shared-types": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/build-pack/node_modules/@devvit/protos": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/protos/-/protos-0.13.4.tgz",
+      "integrity": "sha512-J6Mqt4crVBZ4rVxGUTuQOoe91UVtyxJDBg0jzieGTlVRtnMT+3DZzobPGDWe2vhz6UwPtznUKXCW220nRlBzAg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "protobufjs": "7.5.8",
+        "rxjs": "7.8.1"
+      },
+      "peerDependencies": {
+        "twirp-ts": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "twirp-ts": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@devvit/build-pack/node_modules/@devvit/public-api": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/public-api/-/public-api-0.13.4.tgz",
+      "integrity": "sha512-k8kZkSZQslrnFNClu2vgQL2H/c6tC359r+F30c82+tMIS9CLAAdTEGFQ9Tbzw+DPNX8q7N3sYqFE/U7Dnoo23A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/metrics": "0.13.4",
+        "@devvit/protos": "0.13.4",
+        "@devvit/shared": "0.13.4",
+        "@devvit/shared-types": "0.13.4",
+        "base64-js": "1.5.1",
+        "clone-deep": "4.0.1",
+        "jwt-decode": "4.0.0",
+        "moderndash": "4.0.0"
+      }
+    },
+    "node_modules/@devvit/build-pack/node_modules/@devvit/public-api/node_modules/@devvit/shared": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/shared/-/shared-0.13.4.tgz",
+      "integrity": "sha512-sZULTST2veBEXOfkMwtQwSTjntvOMoCf10qGJgdeB2jNwTwJ2XIIwJCF3ppeA3ATGKIb/kh8OVwYGt/p2j30nA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "@devvit/shared-types": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/build-pack/node_modules/@devvit/shared-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/shared-types/-/shared-types-0.13.4.tgz",
+      "integrity": "sha512-ZjFK1QDaVsXGWA2aMy5mPzkefi+Nm4+GlDI0pLYPFAau6beXsr5oKpdPkq/ke0WNOGe3S4kmaa9zjNwRR5P5hA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "jsonschema": "1.4.1",
+        "uuid": "14.0.0"
       }
     },
     "node_modules/@devvit/build-pack/node_modules/@esbuild/aix-ppc64": {
@@ -694,6 +800,31 @@
         "@esbuild/win32-x64": "0.25.9"
       }
     },
+    "node_modules/@devvit/build-pack/node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@devvit/build-pack/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -702,16 +833,72 @@
       "license": "MIT"
     },
     "node_modules/@devvit/builders": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@devvit/builders/-/builders-0.13.0.tgz",
-      "integrity": "sha512-FAOOz5QfvJumSMKY0aq2zh5AIxohuPyse/0zvxVhrOUZv1YJsmpgtEBQeffd4mIcRsaT7P1FwK4k+Hs1MLCgPA==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/builders/-/builders-0.13.4.tgz",
+      "integrity": "sha512-/aiOvInRTFMJTlHGI56qW0rUVGkwUrK/fW/R+58+A9V+C5kmGtL1RMweQtgFWxIVnfYKbj7M05A89/kQh6AeAA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@devvit/build-pack": "0.13.0",
-        "@devvit/linkers": "0.13.0",
-        "@devvit/protos": "0.13.0",
-        "@devvit/shared-types": "0.13.0"
+        "@devvit/build-pack": "0.13.4",
+        "@devvit/linkers": "0.13.4",
+        "@devvit/protos": "0.13.4",
+        "@devvit/shared-types": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/builders/node_modules/@devvit/protos": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/protos/-/protos-0.13.4.tgz",
+      "integrity": "sha512-J6Mqt4crVBZ4rVxGUTuQOoe91UVtyxJDBg0jzieGTlVRtnMT+3DZzobPGDWe2vhz6UwPtznUKXCW220nRlBzAg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "protobufjs": "7.5.8",
+        "rxjs": "7.8.1"
+      },
+      "peerDependencies": {
+        "twirp-ts": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "twirp-ts": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@devvit/builders/node_modules/@devvit/shared-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/shared-types/-/shared-types-0.13.4.tgz",
+      "integrity": "sha512-ZjFK1QDaVsXGWA2aMy5mPzkefi+Nm4+GlDI0pLYPFAau6beXsr5oKpdPkq/ke0WNOGe3S4kmaa9zjNwRR5P5hA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "jsonschema": "1.4.1",
+        "uuid": "14.0.0"
+      }
+    },
+    "node_modules/@devvit/builders/node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@devvit/cache": {
@@ -726,18 +913,18 @@
       }
     },
     "node_modules/@devvit/cli": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@devvit/cli/-/cli-0.13.0.tgz",
-      "integrity": "sha512-XHEeRMF/zJZG2kkILIuPVBQySAKOtNatPnxNlhAupgNsP+I7HVXV8zIksitNYd/zTgJvlqwwYvJLIy8kgIu8rw==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/cli/-/cli-0.13.4.tgz",
+      "integrity": "sha512-8uohiNMtZoY2Tsabg+YHHD8ye+u2m2vrlPh6FHInWHB2LTfp7yOgekLpUll6c/RtyST64afsM6RVEU0HAbqEWQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@devvit/build-pack": "0.13.0",
-        "@devvit/builders": "0.13.0",
-        "@devvit/linkers": "0.13.0",
-        "@devvit/protos": "0.13.0",
-        "@devvit/public-api": "0.13.0",
-        "@devvit/shared-types": "0.13.0",
+        "@devvit/build-pack": "0.13.4",
+        "@devvit/builders": "0.13.4",
+        "@devvit/linkers": "0.13.4",
+        "@devvit/protos": "0.13.4",
+        "@devvit/public-api": "0.13.4",
+        "@devvit/shared-types": "0.13.4",
         "@improbable-eng/grpc-web": "0.15.0",
         "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
         "@oclif/core": "2.9.4",
@@ -767,13 +954,107 @@
         "string-length": "5.0.1",
         "tiny-glob": "0.2.9",
         "twirp-ts": "2.5.0",
-        "ws": "8.18.0"
+        "ws": "8.20.1"
       },
       "bin": {
         "devvit-cli": "bin/devvit.js"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@devvit/cli/node_modules/@devvit/metrics": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/metrics/-/metrics-0.13.4.tgz",
+      "integrity": "sha512-0CCfLcX7BxnPoJqMpsiSkxMr4yP7YzerSncOrW9cC4M44eqwRCUOmBq8VET6wtx5fyX4asQJwAYhiwTbBpcCZA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/cli/node_modules/@devvit/protos": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/protos/-/protos-0.13.4.tgz",
+      "integrity": "sha512-J6Mqt4crVBZ4rVxGUTuQOoe91UVtyxJDBg0jzieGTlVRtnMT+3DZzobPGDWe2vhz6UwPtznUKXCW220nRlBzAg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "protobufjs": "7.5.8",
+        "rxjs": "7.8.1"
+      },
+      "peerDependencies": {
+        "twirp-ts": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "twirp-ts": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@devvit/cli/node_modules/@devvit/public-api": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/public-api/-/public-api-0.13.4.tgz",
+      "integrity": "sha512-k8kZkSZQslrnFNClu2vgQL2H/c6tC359r+F30c82+tMIS9CLAAdTEGFQ9Tbzw+DPNX8q7N3sYqFE/U7Dnoo23A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/metrics": "0.13.4",
+        "@devvit/protos": "0.13.4",
+        "@devvit/shared": "0.13.4",
+        "@devvit/shared-types": "0.13.4",
+        "base64-js": "1.5.1",
+        "clone-deep": "4.0.1",
+        "jwt-decode": "4.0.0",
+        "moderndash": "4.0.0"
+      }
+    },
+    "node_modules/@devvit/cli/node_modules/@devvit/shared": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/shared/-/shared-0.13.4.tgz",
+      "integrity": "sha512-sZULTST2veBEXOfkMwtQwSTjntvOMoCf10qGJgdeB2jNwTwJ2XIIwJCF3ppeA3ATGKIb/kh8OVwYGt/p2j30nA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "@devvit/shared-types": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/cli/node_modules/@devvit/shared-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/shared-types/-/shared-types-0.13.4.tgz",
+      "integrity": "sha512-ZjFK1QDaVsXGWA2aMy5mPzkefi+Nm4+GlDI0pLYPFAau6beXsr5oKpdPkq/ke0WNOGe3S4kmaa9zjNwRR5P5hA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "jsonschema": "1.4.1",
+        "uuid": "14.0.0"
+      }
+    },
+    "node_modules/@devvit/cli/node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@devvit/client": {
@@ -790,15 +1071,71 @@
       }
     },
     "node_modules/@devvit/linkers": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@devvit/linkers/-/linkers-0.13.0.tgz",
-      "integrity": "sha512-aw3AD5NHJZqESPUY//5OiwVVFPO+vKzHoDfTr0nMf9yTj0PzNJzKR0ZO7SGF/GRrmaX/JS4XlyT6t8epUAPuEw==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/linkers/-/linkers-0.13.4.tgz",
+      "integrity": "sha512-LLzNLTUWWNXHWJ22w51Fa9ebW5jAAa43e47Y7gEEdph1VGErXxIGGv3NQC4vlbq4ZNTtoAN06i4Dq/nbBXK7XQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@devvit/build-pack": "0.13.0",
-        "@devvit/protos": "0.13.0",
-        "@devvit/shared-types": "0.13.0"
+        "@devvit/build-pack": "0.13.4",
+        "@devvit/protos": "0.13.4",
+        "@devvit/shared-types": "0.13.4"
+      }
+    },
+    "node_modules/@devvit/linkers/node_modules/@devvit/protos": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/protos/-/protos-0.13.4.tgz",
+      "integrity": "sha512-J6Mqt4crVBZ4rVxGUTuQOoe91UVtyxJDBg0jzieGTlVRtnMT+3DZzobPGDWe2vhz6UwPtznUKXCW220nRlBzAg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "protobufjs": "7.5.8",
+        "rxjs": "7.8.1"
+      },
+      "peerDependencies": {
+        "twirp-ts": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "twirp-ts": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@devvit/linkers/node_modules/@devvit/shared-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@devvit/shared-types/-/shared-types-0.13.4.tgz",
+      "integrity": "sha512-ZjFK1QDaVsXGWA2aMy5mPzkefi+Nm4+GlDI0pLYPFAau6beXsr5oKpdPkq/ke0WNOGe3S4kmaa9zjNwRR5P5hA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@devvit/protos": "0.13.4",
+        "jsonschema": "1.4.1",
+        "uuid": "14.0.0"
+      }
+    },
+    "node_modules/@devvit/linkers/node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@devvit/media": {
@@ -1762,9 +2099,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -1790,9 +2127,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -2340,9 +2677,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3246,13 +3583,13 @@
       }
     },
     "node_modules/devvit": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/devvit/-/devvit-0.13.0.tgz",
-      "integrity": "sha512-otLG/Yp3t6y81h5otb4IRYDv5TNFH4LEQIW3oeyi1IMp5wX2YcHPbdxVGtx4SEMqmOK3PH+aoQkj1qZWNJ4zZg==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/devvit/-/devvit-0.13.4.tgz",
+      "integrity": "sha512-RGETUHenSzCJhv0QKHTdxxaaDiTRxFajWjAgIRY+C/noRdLwJZ6PGhJ+FCKVL+f+OTYCBCf6sfCfnTTGqA6N5g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@devvit/cli": "0.13.0"
+        "@devvit/cli": "0.13.4"
       },
       "bin": {
         "devvit": "bin/devvit.js"
@@ -3784,17 +4121,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4133,9 +4470,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5392,9 +5729,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true,
       "license": "MIT"
     },
@@ -7289,9 +7626,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
-      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7355,9 +7692,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@devvit/public-api": "0.13.0",
     "@types/node": "^22.10.5",
-    "devvit": "0.13.0",
+    "devvit": "0.13.4",
     "typescript": "5.8.3"
   },
   "engines": {


### PR DESCRIPTION
## Summary

- Update the project-local Devvit CLI from `0.13.0` to `0.13.4`.
- Run `npx devvit update app` so `@devvit/public-api`, `@devvit/start`, and `@devvit/web` are also synced to `0.13.4`.
- Refresh `package-lock.json` so installs reproduce the synced Devvit dependency tree.

## Context

Devvit's current docs recommend updating the project-local CLI and then running `npx devvit update app` so playtest uses matching `@devvit/*` packages.

## Validation

- `npx devvit --version` -> `@devvit/cli/0.13.4`
- `npm ls devvit @devvit/public-api @devvit/start @devvit/web --depth=0`
- `npx devvit update app`
- `npm run check`
- `npm test`
- `npm run build`