### PR TITLE
[codex] Add feature education wizard flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ structure — do not re-merge the modules back into one file.**
 | `flair.ts` | Approval flair config, template validation, viewer flair snapshots, verification flair checks |
 | `search.ts` | Pending/approved/history/audit search, moderator stats |
 | `dashboard.ts` | Hub/mod dashboard loaders, state payload builders (`toHubState` / `toModPanelState`) |
-| `onboarding.ts` | Per-moderator onboarding completion tracking for the mod panel walkthrough |
+| `onboarding.ts` | Per-moderator onboarding completion tracking and versioned feature-education packs for the mod panel wizard |
 | `settings.ts` | Runtime config, settings save handlers, validators, configurable deny reasons |
 | `theme.ts` | Theme presets + color derivation |
 | `retention.ts` | Validation scheduling, retention reconcile, history prune, audit purge (scheduled jobs) |
@@ -42,13 +42,23 @@ The client UI lives in `src/client/` (`hub-app.js`, `mod-panel.js`,
 `mod-panel.css`, etc.) and is a separate bundle — it talks to the server only
 over the HTTP routes defined in `src/index.ts`, never by importing `src/core`.
 
-The mod panel setup/onboarding wizard lives in `src/client/mod-panel.html`,
+The mod panel setup/onboarding/feature wizard lives in `src/client/mod-panel.html`,
 `src/client/mod-panel.js`, and `src/client/mod-panel.css`. Server state for the
 wizard flows through `DashboardData` / `ModPanelStatePayload`
-(`requiresInitialSetup`, `needsOnboarding`) and `/api/mod/onboarding/complete`;
-per-moderator completion storage belongs in `src/core/onboarding.ts`. Keep
-wizard debug controls production-safe: `wizardDebugMode` is a manual boolean
-debug switch, and forced mode should stay `null` in production.
+(`requiresInitialSetup`, `needsOnboarding`, `newFeaturePacks`) and
+`/api/mod/onboarding/complete` / `/api/mod/feature-education/complete`;
+per-moderator onboarding and feature-education completion storage belongs in
+`src/core/onboarding.ts`. Wizard mode priority is **setup > onboarding >
+features**: setup suppresses onboarding/features, and onboarding suppresses
+feature packs. Completing setup/onboarding also marks current feature packs
+complete so new moderators do not see back-to-back tours. Feature-education
+completion keys are per subreddit/moderator/pack and expire after the long TTL
+in `FEATURE_EDUCATION_COMPLETION_TTL_DAYS`; the normal onboarding completion
+key stays durable. Keep feature packs in `CURRENT_FEATURE_EDUCATION_PACKS` long
+enough for slow-updating communities to catch up, and remove old packs only
+after their `retainUntilAtLeast` version has passed. Keep wizard debug controls
+production-safe: `wizardDebugMode` is a manual boolean debug switch, and forced
+mode should stay `null` in production.
 
 ## Current product behavior
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Full changelog:
 [https://www.reddit.com/r/vouchx/wiki/changelog/](https://www.reddit.com/r/vouchx/wiki/changelog/)
 
 
-### v1.5.5
+### v1.5.6
 
 #### New Features
 - Added a Denial tag to queue cards. Tap it to view the most recent denial details.
@@ -125,7 +125,7 @@ Full changelog:
 - When a submission contains multiple photos, you can now swipe left or right while viewing an enlarged image to move between photos.
 - Removed Terms Accepted and Age Confirmed timestamps from queue cards to reduce clutter. This information is still retained internally for auditing and tracking purposes.
 - Improved Android photo instructions behavior.
-- Fixed wizard completion behavior.
+- Fixed wizard completion behavior and added support for new features in wizard.
 
 
 ---

--- a/src/client/mod-panel.css
+++ b/src/client/mod-panel.css
@@ -1012,6 +1012,16 @@ body.wizard-scroll-locked {
   margin-bottom: var(--space-6);
 }
 
+.wizard-feature-list {
+  display: grid;
+  gap: var(--space-2);
+  width: 100%;
+  margin: 0;
+  padding-left: var(--space-6);
+  color: var(--text);
+  font-size: var(--text-body);
+}
+
 .wizard-modal-actions {
   gap: var(--space-3);
 }

--- a/src/client/mod-panel.css
+++ b/src/client/mod-panel.css
@@ -1188,6 +1188,16 @@ body.wizard-scroll-locked {
 }
 
 .wizard-demo-bulkbar {
+  /* Float at the bottom like the real batch toolbar, lifted to sit just above the wizard
+     banner (which is fixed to bottom: 0). --wizard-banner-height is published by
+     updateWizardBannerSpacing(). */
+  position: fixed;
+  left: max(14px, calc((100vw - 1120px) / 2 + 14px));
+  right: max(14px, calc((100vw - 1120px) / 2 + 14px));
+  bottom: calc(var(--wizard-banner-height, 0px) + 12px);
+  z-index: 50;
+  max-width: 1092px;
+  margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1195,9 +1205,9 @@ body.wizard-scroll-locked {
   gap: var(--space-4);
   padding: var(--space-4) var(--space-5);
   border-radius: 12px;
-  scroll-margin-top: 120px;
   background: color-mix(in srgb, var(--primary-soft) 30%, var(--panel-surface-strong) 70%);
   border: 1px solid color-mix(in srgb, var(--primary) 28%, var(--panel-border) 72%);
+  box-shadow: 0 18px 50px color-mix(in srgb, #000 28%, transparent);
 }
 
 .wizard-demo-bulkbar-count {
@@ -3000,6 +3010,15 @@ button.pending-age-denied-before:focus-visible {
 .footer-link-muted {
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+.footer-link-button {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
 }
 
 .storage-percent {

--- a/src/client/mod-panel.html
+++ b/src/client/mod-panel.html
@@ -178,6 +178,9 @@
                     <span class="wizard-demo-badge">Example</span>
                   </div>
                   <p class="wizard-demo-meta">Account age 142d · 3.2k karma · 2 photos submitted</p>
+                  <div class="pending-badge-row queue-trust-row">
+                    <button id="wizard-demo-denied-before" class="pending-age-badge pending-age-denied-before" type="button" tabindex="-1">Denied x2</button>
+                  </div>
                   <div class="wizard-demo-thumbs" aria-hidden="true"><span></span><span></span></div>
                   <div class="row wizard-demo-actions">
                     <button id="wizard-demo-approve" class="btn btn-success" type="button" tabindex="-1">Approve</button>

--- a/src/client/mod-panel.html
+++ b/src/client/mod-panel.html
@@ -215,7 +215,7 @@
                 <article class="item queue-card wizard-demo-card">
                   <div class="queue-card-header">
                     <div class="queue-card-identity">
-                      <label class="pending-select-toggle"><input type="checkbox" class="wizard-demo-checkbox" tabindex="-1" aria-label="Example select" /></label>
+                      <label id="wizard-demo-select-2" class="pending-select-toggle"><input type="checkbox" class="wizard-demo-checkbox" tabindex="-1" aria-label="Example select" /></label>
                       <span class="wizard-demo-username">u/another_member</span>
                     </div>
                     <span class="wizard-demo-badge">Example</span>
@@ -1152,6 +1152,11 @@
             target="_blank"
             rel="noopener noreferrer"
           >Report a Bug / Request a Feature</a>
+          <button
+            id="replay-wizard-link"
+            class="muted small footer-link-muted footer-link-button hidden"
+            type="button"
+          >Replay walkthrough</button>
         </div>
       </footer>
     </div>

--- a/src/client/mod-panel.js
+++ b/src/client/mod-panel.js
@@ -521,13 +521,12 @@ import brandVxUrl from './brand-vx.png';
   } catch (_e) {
     // localStorage unavailable
   }
-  // Manual toggle: false in production (wizard shows based on real state). The Devvit mod
-  // panel webview can't take URL params, so flip this to `true` here in code to force the
-  // wizard on for testing.
+  // Manual toggle: false in production
   const wizardDebugMode = false;
-  // Force a specific mode while debugging ('setup' | 'onboarding' | null). Keep null in production.
+  // Force a specific mode while debugging ('setup' | 'onboarding' | 'features' | null). Keep null in production.
   const wizardForceMode = null;
-  let wizardMode = null; // 'setup' | 'onboarding' | null — locked once the wizard starts
+  let wizardMode = null; // 'setup' | 'onboarding' | 'features' | null — locked once the wizard starts
+  let wizardFeaturePacks = [];
   let wizardActiveSteps = []; // master steps filtered for the current mode + permissions
   let wizardStep = -1;
   let wizardPhase = 'navigate'; // 'navigate' | 'learn' — tour steps start in navigate
@@ -5411,19 +5410,59 @@ import brandVxUrl from './brand-vx.png';
 
   // === Setup Wizard ===
 
-  function getWizardStorageKey() {
+  function getPendingFeaturePacks() {
+    const packs = state && Array.isArray(state.newFeaturePacks) ? state.newFeaturePacks : [];
+    const pendingPacks = packs
+      .map((pack) => ({
+        id: String(pack && pack.id ? pack.id : '').trim().toLowerCase(),
+        title: String(pack && pack.title ? pack.title : '').trim(),
+        summary: String(pack && pack.summary ? pack.summary : '').trim(),
+        stepIds: Array.isArray(pack && pack.stepIds)
+          ? pack.stepIds.map((stepId) => String(stepId || '').trim()).filter(Boolean)
+        : [],
+      }))
+      .filter((pack) => pack.id && pack.stepIds.length > 0);
+    if (pendingPacks.length > 0 || !wizardDebugMode || wizardForceMode !== 'features') {
+      return pendingPacks;
+    }
+    return getDebugFeaturePacks();
+  }
+
+  function getDebugFeaturePacks() {
+    const stepIds = WIZARD_STEPS.filter((step) => step.debugFeatureStep).map((step) => step.id);
+    return stepIds.length > 0
+      ? [
+          {
+            id: 'debug-current-features',
+            title: 'Current feature tour',
+            summary: 'Debug preview of the current new-feature wizard steps.',
+            stepIds,
+          },
+        ]
+      : [];
+  }
+
+  function getWizardRunStorageId(mode, featurePacks = []) {
+    if (mode === 'features') {
+      const ids = featurePacks.map((pack) => pack.id).filter(Boolean).sort();
+      return `features:${ids.join('+') || 'none'}`;
+    }
+    return mode || 'unknown';
+  }
+
+  function getWizardStorageKey(mode, featurePacks = []) {
     const subredditId = (queryParams.get('subredditId') || 'unknown').trim().toLowerCase();
     // Scope per-moderator so a shared browser doesn't let one mod's completion suppress
     // another's wizard. Redis (needsOnboarding) remains the cross-device source of truth;
     // this key is only a per-device convenience (mid-tour step + re-flash suppression).
     const viewer = String((state && state.viewerUsername) || 'anon').trim().toLowerCase().replace(/^u\//, '');
-    return `vx-wizard-v1:${subredditId}:${viewer || 'anon'}`;
+    return `vx-wizard-v2:${subredditId}:${viewer || 'anon'}:${getWizardRunStorageId(mode, featurePacks)}`;
   }
 
-  function readWizardStorage() {
+  function readWizardStorage(mode, featurePacks = []) {
     if (wizardDebugMode) return null; // Always start fresh in debug mode
     try {
-      const raw = window.localStorage.getItem(getWizardStorageKey());
+      const raw = window.localStorage.getItem(getWizardStorageKey(mode, featurePacks));
       return raw ? JSON.parse(raw) : null;
     } catch (_e) {
       return null;
@@ -5433,27 +5472,34 @@ import brandVxUrl from './brand-vx.png';
   function writeWizardStorage(step, done) {
     if (wizardDebugMode) return; // Don't persist in debug mode
     try {
-      window.localStorage.setItem(getWizardStorageKey(), JSON.stringify({ step: Number(step), done: Boolean(done) }));
+      window.localStorage.setItem(
+        getWizardStorageKey(wizardMode, wizardFeaturePacks),
+        JSON.stringify({ step: Number(step), done: Boolean(done) })
+      );
     } catch (_e) {}
   }
 
   // 'setup' = first-time configuration (requires settings access); 'onboarding' = one-time
-  // panel tour for reviewers after setup is complete. Debug mode forces whichever fits.
+  // panel tour for reviewers after setup is complete; 'features' = short tours for
+  // versioned feature packs added after a moderator's original onboarding.
   function resolveWizardMode() {
     if (!state) return null;
     if (wizardDebugMode && wizardForceMode) return wizardForceMode; // TEMP testing override
     if (state.requiresInitialSetup && state.canAccessSettingsTab) return 'setup';
     if (wizardDebugMode) return 'onboarding';
     if (state.needsOnboarding) return 'onboarding';
+    if (getPendingFeaturePacks().length > 0) return 'features';
     return null;
   }
 
   function shouldShowWizard() {
     if (!state) return false;
     if (wizardForcedRun) return true; // Manual replay bypasses the one-time onboarding gate.
-    if (resolveWizardMode() === null) return false;
+    const mode = resolveWizardMode();
+    if (mode === null) return false;
     if (wizardDebugMode) return true; // Always show a wizard when debugging
-    const stored = readWizardStorage();
+    const featurePacks = mode === 'features' ? getPendingFeaturePacks() : [];
+    const stored = readWizardStorage(mode, featurePacks);
     if (stored && stored.done) return false;
     return true;
   }
@@ -5464,11 +5510,52 @@ import brandVxUrl from './brand-vx.png';
   // tab requires config access" install setting is off, otherwise config-permission only.
   function buildWizardActiveSteps(mode) {
     const canSettings = Boolean(state && state.canAccessSettingsTab);
+    if (mode === 'features') {
+      return buildFeatureWizardActiveSteps(getPendingFeaturePacks(), canSettings);
+    }
     return WIZARD_STEPS.filter((step) => {
       if (mode === 'onboarding' && step.setupOnly) return false;
       if (step.requiresConfigAccess && !canSettings) return false;
       return true;
     });
+  }
+
+  function buildFeatureWizardActiveSteps(featurePacks, canSettings) {
+    const packs = Array.isArray(featurePacks) ? featurePacks : [];
+    const stepIds = new Set(packs.flatMap((pack) => pack.stepIds || []));
+    const featureSteps = WIZARD_STEPS.filter((step) => {
+      if (!stepIds.has(step.id)) return false;
+      if (step.requiresConfigAccess && !canSettings) return false;
+      return true;
+    });
+    if (featureSteps.length === 0) {
+      return [];
+    }
+    const title = packs.length === 1 && packs[0].title ? packs[0].title : 'New VouchX features';
+    const summary =
+      packs.length === 1 && packs[0].summary
+        ? packs[0].summary
+        : 'A few moderator tools changed since your last walkthrough. Here is the quick version.';
+    return [
+      {
+        id: 'feature-welcome',
+        type: 'modal',
+        kicker: 'New in VouchX',
+        title,
+        body: summary,
+        featurePacks: packs,
+        primaryBtn: 'Show Me',
+      },
+      ...featureSteps,
+      {
+        id: 'feature-complete',
+        type: 'modal',
+        kicker: 'New features',
+        title: "You're up to date",
+        body: 'That covers the latest moderator-facing changes. You can replay the full walkthrough from the footer anytime.',
+        primaryBtn: 'Got it',
+      },
+    ];
   }
 
   function resolveWizardStepCopy(stepDef) {
@@ -5553,16 +5640,16 @@ import brandVxUrl from './brand-vx.png';
       demoDenyOpen: true,
       spotlightElementId: 'wizard-demo-deny-panel',
     },
-    // Demo: peer review — request a 2nd opinion + shared notes
+    // Demo: previous-denial badges keep repeat-attempt context behind a compact control
     {
-      id: 'demo-peer-review',
+      id: 'demo-denial-badges',
       type: 'banner',
-      title: 'Ask for peer review',
-      body: 'Not sure about a request? Tap Peer Review to flag it for the team. It jumps to the top of the queue and any moderator can add notes here to compare findings. The flag and its notes clear automatically once the request is approved, denied, or peer review is cancelled.',
+      title: 'Previous-denial badges',
+      body: 'When a member has been denied before, the Queue shows a Denied before or Denied xN badge. Tap it on a real request to open the latest denial details without crowding the card.',
       tab: 'pending',
       isDemoStep: true,
-      demoPeerReviewOpen: true,
-      spotlightElementId: 'wizard-demo-peer-review-panel',
+      debugFeatureStep: true,
+      spotlightElementId: 'wizard-demo-denied-before',
     },
     // Demo: bulk review — checkmarks select, bar docks at the bottom. Handled without the
     // dimming spotlight (see the isDemoBulk branch in renderWizard) so the pulsing card
@@ -5575,6 +5662,18 @@ import brandVxUrl from './brand-vx.png';
       tab: 'pending',
       isDemoStep: true,
       isDemoBulk: true,
+    },
+    // Demo: peer review — request a 2nd opinion + shared notes
+    {
+      id: 'demo-peer-review',
+      type: 'banner',
+      title: 'Ask for peer review',
+      body: 'Not sure about a request? Tap Peer Review to flag it for the team. It jumps to the top of the queue and any moderator can add notes here to compare findings. The flag and its notes clear automatically once the request is approved, denied, or peer review is cancelled.',
+      tab: 'pending',
+      isDemoStep: true,
+      demoPeerReviewOpen: true,
+      debugFeatureStep: true,
+      spotlightElementId: 'wizard-demo-peer-review-panel',
     },
     // History
     {
@@ -5994,7 +6093,7 @@ import brandVxUrl from './brand-vx.png';
     const stepNumber = wizardBannerNumberFor(wizardStep);
     const stepTotal = wizardBannerTotalCount();
     const copy = resolveWizardStepCopy(stepDef);
-    const progressLabel = wizardMode === 'onboarding' ? 'Tour' : 'Setup';
+    const progressLabel = wizardMode === 'features' ? 'New features' : wizardMode === 'onboarding' ? 'Tour' : 'Setup';
 
     if (wizardMinimized) {
       wizardBannerInner.classList.add('hidden');
@@ -6060,7 +6159,24 @@ import brandVxUrl from './brand-vx.png';
     if (wizardModalHint) wizardModalHint.classList.toggle('hidden', !stepDef.hasHintReminder);
     if (wizardModalExtras) {
       wizardModalExtras.innerHTML = '';
-      if (stepDef.hasGuideLink) {
+      const featurePacks = Array.isArray(stepDef.featurePacks) ? stepDef.featurePacks : [];
+      if (featurePacks.length > 1) {
+        wizardModalExtras.classList.remove('hidden');
+        const list = document.createElement('ul');
+        list.className = 'wizard-feature-list';
+        for (const pack of featurePacks) {
+          const title = String(pack && pack.title ? pack.title : '').trim();
+          if (!title) continue;
+          const item = document.createElement('li');
+          item.textContent = title;
+          list.appendChild(item);
+        }
+        if (list.childElementCount > 0) {
+          wizardModalExtras.appendChild(list);
+        } else {
+          wizardModalExtras.classList.add('hidden');
+        }
+      } else if (stepDef.hasGuideLink) {
         wizardModalExtras.classList.remove('hidden');
         const guideUrl = normalizeExternalUrl(MODERATOR_GUIDE_URL);
         if (guideUrl) {
@@ -6117,18 +6233,29 @@ import brandVxUrl from './brand-vx.png';
     hideWizardDemo();
   }
 
-  function markOnboardingCompletedOnServer() {
+  function markWizardCompletedOnServer(completedMode, completedFeaturePacks) {
     if (wizardDebugMode) return; // don't pollute real state while debugging
+    if (completedMode === 'features') {
+      const packIds = (completedFeaturePacks || []).map((pack) => pack.id).filter(Boolean);
+      if (packIds.length > 0) {
+        void requestJson('/api/mod/feature-education/complete', { packIds }).catch(() => {});
+      }
+      return;
+    }
     // Fire-and-forget: records that this moderator has been through the walkthrough so it
-    // never shows again (setup completion counts as onboarding too).
+    // never shows again (setup completion counts as onboarding too). The server also marks
+    // current feature education packs complete so brand-new mods do not get a second tour.
     void requestJson('/api/mod/onboarding/complete', {}).catch(() => {});
   }
 
   function completeWizard() {
+    const completedMode = wizardMode;
+    const completedFeaturePacks = wizardFeaturePacks.slice();
     writeWizardStorage(wizardStep, true);
-    markOnboardingCompletedOnServer();
+    markWizardCompletedOnServer(completedMode, completedFeaturePacks);
     wizardStep = -1;
     wizardMode = null;
+    wizardFeaturePacks = [];
     wizardActiveSteps = [];
     wizardLastRenderedStep = -1;
     wizardForcedRun = false; // End any manual replay so the gate applies again.
@@ -6155,8 +6282,13 @@ import brandVxUrl from './brand-vx.png';
       }
       // Lock the mode + active step list for this run.
       wizardMode = resolveWizardMode();
+      wizardFeaturePacks = wizardMode === 'features' ? getPendingFeaturePacks() : [];
       wizardActiveSteps = buildWizardActiveSteps(wizardMode);
-      const stored = readWizardStorage();
+      if (wizardActiveSteps.length === 0) {
+        hideAllWizardUi();
+        return;
+      }
+      const stored = readWizardStorage(wizardMode, wizardFeaturePacks);
       const storedStep = stored && typeof stored.step === 'number' ? stored.step : 0;
       wizardStep = Math.min(Math.max(0, storedStep), wizardActiveSteps.length - 1);
       writeWizardStorage(wizardStep, false);

--- a/src/client/mod-panel.js
+++ b/src/client/mod-panel.js
@@ -282,6 +282,7 @@ import brandVxUrl from './brand-vx.png';
   const textareaLinkCancelBtn = document.getElementById('textarea-link-cancel-btn');
   const textareaLinkInsertBtn = document.getElementById('textarea-link-insert-btn');
   const bugReportLink = document.getElementById('bug-report-link');
+  const replayWizardLink = document.getElementById('replay-wizard-link');
   const wizardOverlay = document.getElementById('wizard-overlay');
   const wizardSpotlightRing = document.getElementById('wizard-spotlight-ring');
   const wizardBanner = document.getElementById('wizard-banner');
@@ -531,6 +532,9 @@ import brandVxUrl from './brand-vx.png';
   let wizardStep = -1;
   let wizardPhase = 'navigate'; // 'navigate' | 'learn' — tour steps start in navigate
   let wizardMinimized = false;
+  // Set while the footer "Replay walkthrough" run is in progress so the wizard's own
+  // shouldShowWizard()/needsOnboarding gates don't tear it down for an already-onboarded mod.
+  let wizardForcedRun = false;
   let wizardLastRenderedStep = -1;
   let wizardSpotlightTargetEl = null;
   let wizardHighlightedEls = [];
@@ -1789,7 +1793,11 @@ import brandVxUrl from './brand-vx.png';
     const appPageUrl = buildInstallSettingsUrl();
     const canUpdateNow = Boolean(state && state.canOpenInstallSettings === true && appPageUrl);
     const sessionDismissed = Boolean(notice && isCriticalUpdateNoticeDismissedForSession(notice));
-    const isVisible = Boolean(notice && !sessionDismissed);
+    // While the wizard is actively on screen (a step showing, or about to start), suppress
+    // update notices entirely — even critical ones — so the walkthrough isn't interrupted.
+    // Minimized is a carve-out: the mod has set the guide aside, so notices surface normally.
+    const wizardActive = !wizardMinimized && (wizardStep >= 0 || shouldShowWizard());
+    const isVisible = Boolean(notice && !sessionDismissed && !wizardActive);
     const isCriticalCopy = Boolean(notice && notice.critical && canUpdateNow);
     const title = notice && notice.title ? notice.title : '';
     const copy = notice
@@ -5442,6 +5450,7 @@ import brandVxUrl from './brand-vx.png';
 
   function shouldShowWizard() {
     if (!state) return false;
+    if (wizardForcedRun) return true; // Manual replay bypasses the one-time onboarding gate.
     if (resolveWizardMode() === null) return false;
     if (wizardDebugMode) return true; // Always show a wizard when debugging
     const stored = readWizardStorage();
@@ -5555,7 +5564,9 @@ import brandVxUrl from './brand-vx.png';
       demoPeerReviewOpen: true,
       spotlightElementId: 'wizard-demo-peer-review-panel',
     },
-    // Demo: bulk review — checkmarks select, bar acts on all
+    // Demo: bulk review — checkmarks select, bar docks at the bottom. Handled without the
+    // dimming spotlight (see the isDemoBulk branch in renderWizard) so the pulsing card
+    // checkboxes and the bottom bar are both visible at once.
     {
       id: 'demo-bulk',
       type: 'banner',
@@ -5564,7 +5575,6 @@ import brandVxUrl from './brand-vx.png';
       tab: 'pending',
       isDemoStep: true,
       isDemoBulk: true,
-      spotlightElementId: 'wizard-demo-bulkbar',
     },
     // History
     {
@@ -5972,6 +5982,8 @@ import brandVxUrl from './brand-vx.png';
     const shown = !wizardBanner.classList.contains('hidden');
     // Reserve space at the bottom so content can scroll clear of the fixed bottom bar.
     document.body.style.paddingBottom = shown ? `${wizardBanner.offsetHeight + 24}px` : '';
+    // Publish the banner height so the demo bulk bar can dock just above it.
+    document.documentElement.style.setProperty('--wizard-banner-height', shown ? `${wizardBanner.offsetHeight}px` : '0px');
   }
 
   function renderWizardBanner(stepDef) {
@@ -6119,10 +6131,16 @@ import brandVxUrl from './brand-vx.png';
     wizardMode = null;
     wizardActiveSteps = [];
     wizardLastRenderedStep = -1;
+    wizardForcedRun = false; // End any manual replay so the gate applies again.
     hideAllWizardUi();
     // The final steps leave the mod on the Settings/Templates tab — drop them back on the
     // Queue so they land where day-to-day review happens.
     setTab('pending');
+    // Wizard suppressed update notices while it ran; re-render now so any pending
+    // (including critical) notice surfaces immediately instead of waiting for a refresh.
+    renderUpdateNotice();
+    // Offer the replay entry point again now that the run is over.
+    renderFooterMeta();
   }
 
   function renderWizard() {
@@ -6155,6 +6173,10 @@ import brandVxUrl from './brand-vx.png';
     const stepChanged = wizardStep !== wizardLastRenderedStep;
     wizardLastRenderedStep = wizardStep;
 
+    // The bulk demo raises the inert example above a hole-less blocking overlay; keep the
+    // body flag in sync every render so it clears on modal/minimized/other steps.
+    document.body.classList.toggle('wizard-demo-bulk-active', !wizardMinimized && Boolean(stepDef.isDemoBulk));
+
     if (stepDef.type === 'modal') {
       hideWizardBanner();
       hideWizardSpotlight();
@@ -6183,6 +6205,32 @@ import brandVxUrl from './brand-vx.png';
       renderWizardDemo(stepDef);
     } else {
       hideWizardDemo();
+    }
+
+    // Bulk demo: cover the screen with the dim overlay but punch NO hole, so every click
+    // lands on the overlay (blocked) except the banner's Next button, which sits above it.
+    // The example queue + bottom bar are raised above the dim and made inert (see
+    // .wizard-demo-bulk-active in CSS): they stay bright and the checkboxes pulse, but they
+    // can't be actioned — and with scroll frozen the mod can't reach the real queue cards
+    // below and approve/deny one by mistake.
+    if (stepDef.isDemoBulk) {
+      hideWizardInlineDetail();
+      // Clear any prior step's spotlight target/ring/hole + scroll lock first.
+      hideWizardSpotlight();
+      applyWizardFieldHighlights(['wizard-demo-select', 'wizard-demo-select-2']);
+      if (wizardOverlay) {
+        clearWizardOverlayHole();
+        wizardOverlay.classList.remove('hidden');
+      }
+      // Bring the example into view, then freeze scrolling once it settles.
+      if (wizardDemoQueue) {
+        wizardDemoQueue.scrollIntoView({ behavior: 'auto', block: 'start' });
+      }
+      window.setTimeout(() => {
+        const current = wizardActiveSteps[wizardStep];
+        if (current && current.isDemoBulk) lockWizardScroll();
+      }, 120);
+      return;
     }
 
     // Config step: highlight both fields in place (no dimming) with details shown inline
@@ -6796,12 +6844,39 @@ import brandVxUrl from './brand-vx.png';
   }
 
   function renderFooterMeta() {
-    if (!bugReportLink) {
+    if (bugReportLink) {
+      const bugReportUrl = normalizeExternalUrl(BUG_REPORT_URL);
+      bugReportLink.classList.toggle('hidden', !bugReportUrl);
+      bugReportLink.setAttribute('href', bugReportUrl || '#');
+    }
+    if (replayWizardLink) {
+      // Available once the panel has loaded; hidden while a wizard run is active (a step
+      // showing or minimized mid-tour — both are resumable, so no need to offer a replay).
+      const wizardRunActive = wizardStep >= 0;
+      replayWizardLink.classList.toggle('hidden', !state || wizardRunActive);
+    }
+  }
+
+  // Re-run the onboarding walkthrough on demand, bypassing the one-time needsOnboarding gate.
+  // Setup stays config-driven, so the manual replay always runs the informational tour.
+  function startWizardReplay() {
+    if (!state) {
       return;
     }
-    const bugReportUrl = normalizeExternalUrl(BUG_REPORT_URL);
-    bugReportLink.classList.toggle('hidden', !bugReportUrl);
-    bugReportLink.setAttribute('href', bugReportUrl || '#');
+    wizardMode = 'onboarding';
+    wizardActiveSteps = buildWizardActiveSteps('onboarding');
+    if (wizardActiveSteps.length === 0) {
+      return;
+    }
+    wizardForcedRun = true;
+    wizardStep = 0;
+    wizardPhase = 'navigate';
+    wizardMinimized = false;
+    wizardLastRenderedStep = -1;
+    writeWizardStorage(0, false);
+    renderWizard();
+    renderUpdateNotice();
+    renderFooterMeta();
   }
 
   function createPhotoWrap(url, alt, gallery, galleryIndex) {
@@ -7796,6 +7871,10 @@ import brandVxUrl from './brand-vx.png';
 
   bindExternalNavigationLink(bugReportLink, () => BUG_REPORT_URL, 'Bug report URL is not configured.');
 
+  if (replayWizardLink) {
+    replayWizardLink.addEventListener('click', startWizardReplay);
+  }
+
   document.querySelectorAll('.textarea-helper-toolbar').forEach((toolbar) => {
     bindTextareaHelperToolbar(toolbar);
   });
@@ -8551,6 +8630,8 @@ import brandVxUrl from './brand-vx.png';
       hideWizardSpotlight();
       const stepDef = wizardActiveSteps[wizardStep];
       if (stepDef) renderWizardBanner(stepDef);
+      // Minimizing is the carve-out where suppressed update notices may surface.
+      renderUpdateNotice();
     });
   }
 
@@ -8559,6 +8640,8 @@ import brandVxUrl from './brand-vx.png';
       wizardMinimized = false;
       // Full re-render restores the spotlight + scroll lock for the current step.
       renderWizard();
+      // Back on screen — re-suppress any update notice.
+      renderUpdateNotice();
     });
   }
 

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -24,6 +24,7 @@ import {
   parsePendingReviewFlag,
   denyVerification,
   dismissModeratorUpdateNotice,
+  getPendingModeratorFeatureEducationPacks,
   ensureUserValidationSchedule,
   getCurrentModeratorPermissionList,
   getHubModeratorUiState,
@@ -33,6 +34,8 @@ import {
   getViewerFlairSnapshot,
   isViewerAwaitingFlairPropagation,
   loadApprovalFlairOptionsForSettings,
+  markModeratorFeatureEducationCompleted,
+  markModeratorOnboardingCompleted,
   loadHubDashboard,
   loadModDashboard,
   looksLikeInternalModmailArchiveError,
@@ -208,6 +211,7 @@ function buildDashboardData(overrides: Partial<Parameters<typeof toHubState>[0]>
     },
     requiresInitialSetup: false,
     needsOnboarding: false,
+    newFeaturePacks: [],
     config: buildRuntimeConfig(),
     viewerSnapshot: {
       accountAgeDays: 365,
@@ -5677,6 +5681,72 @@ test('dismissModeratorUpdateNotice stores a per-moderator per-version dismissal 
   assert.equal(updateContext.setCalls.length, 1);
   assert.match(updateContext.setCalls[0][0], /subreddit:t5_example:moderator:update-dismissed:mod_one:0\.0\.3$/);
   assert.ok(expirationOptions?.expiration instanceof Date);
+});
+
+test('getPendingModeratorFeatureEducationPacks surfaces new packs for already-onboarded moderators', async () => {
+  const featureContext = createUpdateNoticeContext({
+    initialDismissals: {
+      'subreddit:t5_example:moderator:onboarded:mod_one': '2026-03-15T00:00:00.000Z',
+    },
+  });
+
+  const packs = await getPendingModeratorFeatureEducationPacks(featureContext.context as never, 'Mod_One');
+
+  assert.deepEqual(
+    packs.map((pack) => ({ id: pack.id, stepIds: pack.stepIds })),
+    [
+      {
+        id: 'peer-review-denial-badges',
+        stepIds: ['demo-peer-review', 'demo-denial-badges'],
+      },
+    ]
+  );
+});
+
+test('markModeratorFeatureEducationCompleted suppresses only the completed feature pack', async () => {
+  const featureContext = createUpdateNoticeContext();
+
+  await withFixedNow('2026-03-15T00:00:00.000Z', async () => {
+    await markModeratorFeatureEducationCompleted(featureContext.context as never, 'Mod_One', [
+      'peer-review-denial-badges',
+    ]);
+  });
+  const packs = await getPendingModeratorFeatureEducationPacks(featureContext.context as never, 'Mod_One');
+  const expirationOptions = featureContext.setCalls[0][2] as { expiration?: Date } | undefined;
+
+  assert.deepEqual(packs, []);
+  assert.equal(featureContext.setCalls.length, 1);
+  assert.match(
+    featureContext.setCalls[0][0],
+    /subreddit:t5_example:moderator:feature-education:mod_one:peer-review-denial-badges$/
+  );
+  assert.equal(expirationOptions?.expiration?.toISOString(), '2027-09-06T00:00:00.000Z');
+});
+
+test('markModeratorOnboardingCompleted also completes current feature education packs', async () => {
+  const featureContext = createUpdateNoticeContext();
+
+  await withFixedNow('2026-03-15T00:00:00.000Z', async () => {
+    await markModeratorOnboardingCompleted(featureContext.context as never, 'Mod_One');
+  });
+  const packs = await getPendingModeratorFeatureEducationPacks(featureContext.context as never, 'Mod_One');
+  const featureCompletionCall = featureContext.setCalls.find((call) =>
+    /subreddit:t5_example:moderator:feature-education:mod_one:peer-review-denial-badges$/.test(call[0])
+  );
+  const featureExpirationOptions = featureCompletionCall?.[2] as { expiration?: Date } | undefined;
+
+  assert.deepEqual(packs, []);
+  assert.ok(
+    featureContext.setCalls.some((call) =>
+      /subreddit:t5_example:moderator:onboarded:mod_one$/.test(call[0])
+    )
+  );
+  assert.ok(
+    featureContext.setCalls.some((call) =>
+      /subreddit:t5_example:moderator:feature-education:mod_one:peer-review-denial-badges$/.test(call[0])
+    )
+  );
+  assert.equal(featureExpirationOptions?.expiration?.toISOString(), '2027-09-06T00:00:00.000Z');
 });
 
 test('toPublicHubConfig omits moderator-only template content', () => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -145,6 +145,7 @@ export type {
   DeleteDataConfirmValues,
   DeleteDataResult,
   DenyReason,
+  FeatureEducationPackState,
   FlairTemplateValidationState,
   HubModeratorUiState,
   HubStatePayload,
@@ -166,6 +167,9 @@ export {
   dismissModeratorUpdateNotice,
 } from './core/update-notice.ts';
 export {
+  getCurrentFeatureEducationPacks,
+  getPendingModeratorFeatureEducationPacks,
   hasCompletedModeratorOnboarding,
+  markModeratorFeatureEducationCompleted,
   markModeratorOnboardingCompleted,
 } from './core/onboarding.ts';

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -33,6 +33,11 @@ export const STALE_RECORD_INDEX_SWEEP_BATCH_SIZE = 200;
 
 export const UPDATE_NOTICE_DISMISS_TTL_DAYS = 7;
 
+// Keep feature-education completion records longer than we keep old feature
+// packs active in code, so a retired pack naturally ages out of Redis after
+// slow-updating communities have had time to catch up.
+export const FEATURE_EDUCATION_COMPLETION_TTL_DAYS = 540;
+
 export const APPROVED_PREFIX_SEARCH_OVERFETCH_MULTIPLIER = 4;
 
 export const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;

--- a/src/core/dashboard.ts
+++ b/src/core/dashboard.ts
@@ -36,7 +36,10 @@ import {
 } from './flair.ts';
 import { pendingIndexKey } from './keys.ts';
 import { clearExpiredPendingClaim } from './locks.ts';
-import { hasCompletedModeratorOnboarding } from './onboarding.ts';
+import {
+  getPendingModeratorFeatureEducationPacks,
+  hasCompletedModeratorOnboarding,
+} from './onboarding.ts';
 import {
   getModeratorAccessSnapshot,
   getSettingsTabRequiresConfigAccess,
@@ -134,6 +137,7 @@ export function toModPanelState(dashboard: DashboardData): ModPanelStatePayload 
     canAccessSettingsTab: dashboard.canAccessSettingsTab,
     requiresInitialSetup: dashboard.requiresInitialSetup,
     needsOnboarding: dashboard.needsOnboarding,
+    newFeaturePacks: dashboard.newFeaturePacks,
     flairTemplateValidation: dashboard.flairTemplateValidation,
     pendingCount: dashboard.pendingCount,
     pending: dashboard.pending.map((record) => toPendingPanelItem(record, dashboard.config)),
@@ -266,10 +270,14 @@ export async function loadDashboardData(
   const requiresInitialSetup = !config.flairTemplateId.trim();
   // Once setup is done, reviewers who haven't been through the panel walkthrough get a
   // one-time onboarding tour. Tracked per-moderator server-side (see onboarding.ts).
-  const needsOnboarding =
-    options.includeModData && canReviewUser && !requiresInitialSetup && viewerIdentity.username
-      ? !(await hasCompletedModeratorOnboarding(context, viewerIdentity.username))
-      : false;
+  let needsOnboarding = false;
+  let newFeaturePacks: DashboardData['newFeaturePacks'] = [];
+  if (options.includeModData && canReviewUser && !requiresInitialSetup && viewerIdentity.username) {
+    needsOnboarding = !(await hasCompletedModeratorOnboarding(context, viewerIdentity.username));
+    if (!needsOnboarding) {
+      newFeaturePacks = await getPendingModeratorFeatureEducationPacks(context, viewerIdentity.username);
+    }
+  }
   const [globalBlockedUsernames, developerUiUsernames] = await Promise.all([
     readMergedGlobalUsernameSettings(context, GLOBAL_BLOCKED_USERNAME_SETTING_NAMES),
     readGlobalUsernameSetting(context, GLOBAL_SETTING_DEVELOPER_UI_USERNAMES),
@@ -454,6 +462,7 @@ export async function loadDashboardData(
     flairTemplateValidation,
     requiresInitialSetup,
     needsOnboarding,
+    newFeaturePacks,
     config,
     viewerSnapshot,
     viewerShouldDisplayVerified,

--- a/src/core/keys.ts
+++ b/src/core/keys.ts
@@ -177,6 +177,12 @@ export function moderatorOnboardingCompletedKey(subredditId: string, moderator: 
   return `${subredditScopePrefix(subredditId)}:moderator:onboarded:${normalizeUsername(moderator)}`;
 }
 
+export function moderatorFeatureEducationCompletedKey(subredditId: string, moderator: string, packId: string): string {
+  return `${subredditScopePrefix(subredditId)}:moderator:feature-education:${normalizeUsername(
+    moderator
+  )}:${packId.trim().toLowerCase()}`;
+}
+
 export function userPendingKeyById(subredditId: string, userId: string): string {
   return `${subredditScopePrefix(subredditId)}:user-id:${normalizeUserId(userId)}:pending`;
 }

--- a/src/core/onboarding.ts
+++ b/src/core/onboarding.ts
@@ -1,5 +1,13 @@
 import type { Devvit } from '@devvit/public-api';
-import { moderatorOnboardingCompletedKey } from './keys.ts';
+import type { FeatureEducationPackState } from './types.ts';
+import {
+  FEATURE_EDUCATION_COMPLETION_TTL_DAYS,
+  MILLIS_PER_DAY,
+} from './constants.ts';
+import {
+  moderatorFeatureEducationCompletedKey,
+  moderatorOnboardingCompletedKey,
+} from './keys.ts';
 import { errorText, sanitizeSubredditId } from './normalize.ts';
 
 /**
@@ -10,6 +18,92 @@ import { errorText, sanitizeSubredditId } from './normalize.ts';
  * ever sees it once, regardless of device (localStorage is per-device and can't
  * answer "who has / hasn't gone through it").
  */
+
+const CURRENT_FEATURE_EDUCATION_PACKS: FeatureEducationPackState[] = [
+  {
+    id: 'peer-review-denial-badges',
+    introducedIn: '1.5.4',
+    retainUntilAtLeast: '1.8.0',
+    title: 'Peer Review and denial badges',
+    summary: 'See how Peer Review keeps second-opinion requests visible and how denial badges surface repeat attempts.',
+    stepIds: ['demo-peer-review', 'demo-denial-badges'],
+  },
+];
+
+function normalizeFeaturePackId(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function cloneFeaturePack(pack: FeatureEducationPackState): FeatureEducationPackState {
+  return {
+    ...pack,
+    stepIds: [...pack.stepIds],
+  };
+}
+
+function featureEducationCompletionExpiration(): Date {
+  return new Date(Date.now() + FEATURE_EDUCATION_COMPLETION_TTL_DAYS * MILLIS_PER_DAY);
+}
+
+export function getCurrentFeatureEducationPacks(): FeatureEducationPackState[] {
+  return CURRENT_FEATURE_EDUCATION_PACKS.map(cloneFeaturePack);
+}
+
+function getKnownFeatureEducationPacks(packIds: readonly string[]): FeatureEducationPackState[] {
+  const requestedIds = new Set(packIds.map(normalizeFeaturePackId).filter(Boolean));
+  if (requestedIds.size === 0) {
+    return [];
+  }
+  return CURRENT_FEATURE_EDUCATION_PACKS.filter((pack) => requestedIds.has(pack.id));
+}
+
+export async function getPendingModeratorFeatureEducationPacks(
+  context: Pick<Devvit.Context, 'redis'> & { subredditId?: string | null },
+  moderator: string
+): Promise<FeatureEducationPackState[]> {
+  try {
+    const subredditId = sanitizeSubredditId(typeof context.subredditId === 'string' ? context.subredditId : '');
+    const normalizedModerator = moderator.trim();
+    if (!subredditId || !normalizedModerator) {
+      return [];
+    }
+    const completionValues = await Promise.all(
+      CURRENT_FEATURE_EDUCATION_PACKS.map((pack) =>
+        context.redis.get(moderatorFeatureEducationCompletedKey(subredditId, normalizedModerator, pack.id))
+      )
+    );
+    return CURRENT_FEATURE_EDUCATION_PACKS.filter((_, index) => !completionValues[index]).map(cloneFeaturePack);
+  } catch (error) {
+    console.log(`Feature education lookup failed: ${errorText(error)}`);
+    // Match onboarding's fail-open posture: Redis trouble should not trap mods
+    // in repeating education flows.
+    return [];
+  }
+}
+
+export async function markModeratorFeatureEducationCompleted(
+  context: Pick<Devvit.Context, 'redis'> & { subredditId?: string | null },
+  moderator: string,
+  packIds: readonly string[]
+): Promise<void> {
+  const subredditId = sanitizeSubredditId(typeof context.subredditId === 'string' ? context.subredditId : '');
+  const normalizedModerator = moderator.trim();
+  const packs = getKnownFeatureEducationPacks(packIds);
+  if (!subredditId || !normalizedModerator || packs.length === 0) {
+    throw new Error('Missing feature education completion details.');
+  }
+  const completedAt = new Date().toISOString();
+  const expiration = featureEducationCompletionExpiration();
+  await Promise.all(
+    packs.map((pack) =>
+      context.redis.set(
+        moderatorFeatureEducationCompletedKey(subredditId, normalizedModerator, pack.id),
+        completedAt,
+        { expiration }
+      )
+    )
+  );
+}
 
 export async function hasCompletedModeratorOnboarding(
   context: Pick<Devvit.Context, 'redis'> & { subredditId?: string | null },
@@ -40,8 +134,16 @@ export async function markModeratorOnboardingCompleted(
   if (!subredditId || !normalizedModerator) {
     throw new Error('Missing onboarding moderator identity.');
   }
-  await context.redis.set(
-    moderatorOnboardingCompletedKey(subredditId, normalizedModerator),
-    new Date().toISOString()
-  );
+  const completedAt = new Date().toISOString();
+  const featureExpiration = featureEducationCompletionExpiration();
+  await Promise.all([
+    context.redis.set(moderatorOnboardingCompletedKey(subredditId, normalizedModerator), completedAt),
+    ...CURRENT_FEATURE_EDUCATION_PACKS.map((pack) =>
+      context.redis.set(
+        moderatorFeatureEducationCompletedKey(subredditId, normalizedModerator, pack.id),
+        completedAt,
+        { expiration: featureExpiration }
+      )
+    ),
+  ]);
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -252,6 +252,7 @@ export type DashboardData = {
   flairTemplateValidation: FlairTemplateValidationState;
   requiresInitialSetup: boolean;
   needsOnboarding: boolean;
+  newFeaturePacks: FeatureEducationPackState[];
   config: RuntimeConfig;
   viewerSnapshot: UserSnapshot;
   viewerShouldDisplayVerified: boolean;
@@ -274,6 +275,15 @@ export type DashboardData = {
   storage: StorageUsage;
   approvedHasMore: boolean;
   auditHasMore: boolean;
+};
+
+export type FeatureEducationPackState = {
+  id: string;
+  introducedIn: string;
+  retainUntilAtLeast: string;
+  title: string;
+  summary: string;
+  stepIds: string[];
 };
 
 export type FlairVerificationCheck = {
@@ -730,6 +740,7 @@ export type ModPanelStatePayload = {
   needsOnboarding: boolean;
   flairTemplateValidation: FlairTemplateValidationState;
   pendingCount: number;
+  newFeaturePacks: FeatureEducationPackState[];
   pending: PendingPanelItem[];
   approved: ApprovedSearchPanelItem[];
   approvedHasMore: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   dismissModeratorUpdateNotice,
   denyVerification,
   ensureUserValidationSchedule,
+  markModeratorFeatureEducationCompleted,
   markModeratorOnboardingCompleted,
   errorText,
   getModeratorAccessSnapshot,
@@ -1262,6 +1263,22 @@ app.post('/api/mod/onboarding/complete', async (_req, res) => {
     const appContext = currentContext();
     const { moderator } = await requireReviewAccess(appContext);
     await markModeratorOnboardingCompleted(appContext, moderator);
+    res.json(await buildModPayload(appContext));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+app.post('/api/mod/feature-education/complete', async (req, res) => {
+  try {
+    const rawPackIds: unknown[] = Array.isArray(req.body?.packIds) ? req.body.packIds : [];
+    const packIds = rawPackIds.map((item) => String(item ?? '').trim()).filter(Boolean);
+    if (packIds.length === 0) {
+      throw httpError(400, 'Missing feature education pack.');
+    }
+    const appContext = currentContext();
+    const { moderator } = await requireReviewAccess(appContext);
+    await markModeratorFeatureEducationCompleted(appContext, moderator, packIds);
     res.json(await buildModPayload(appContext));
   } catch (error) {
     sendError(res, error);


### PR DESCRIPTION
## Summary

- Add versioned moderator feature-education packs alongside the existing setup/onboarding wizard.
- Add Redis-backed per-moderator feature completion keys with long TTL cleanup and wire `newFeaturePacks` through the mod panel payload.
- Extend the existing wizard with a `features` mode, multi-pack intro listing, debug feature preview support, and a denial-badge demo step.

## Validation

- `npm run check`
- `npm test`
- `npm run build`