### PR TITLE
[codex] Improve history tab filtering and navigation

### DIFF
--- a/src/client/mod-panel.css
+++ b/src/client/mod-panel.css
@@ -3257,6 +3257,13 @@ button.pending-age-denied-before:focus-visible {
   width: 100%;
 }
 
+.history-shortcut-label {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--text-meta);
+  font-weight: var(--font-weight-medium);
+}
+
 .history-filter-panel {
   border-bottom: 1px solid color-mix(in srgb, var(--panel-divider) 72%, transparent);
   color: var(--text);

--- a/src/client/mod-panel.html
+++ b/src/client/mod-panel.html
@@ -253,12 +253,13 @@
         <section id="tab-history" class="tab-panel hidden">
           <div class="content-card history-workspace">
             <div class="subtabs segmented-control history-nav">
-              <button id="history-view-approved" class="btn btn-secondary history-view-btn" data-history-view="approved">Approved</button>
+              <button id="history-view-approved" class="btn btn-secondary history-view-btn history-shortcut-btn" data-history-view="approved">Verified members</button>
               <button id="history-view-records" class="btn btn-primary history-view-btn" data-history-view="records">Records</button>
               <button id="history-view-audit" class="btn btn-secondary history-view-btn" data-history-view="audit">Audit</button>
             </div>
 
             <div id="history-panel-approved" class="history-view-panel hidden">
+              <p class="history-shortcut-label">Shortcut: Records filtered to Approved</p>
               <details id="approved-filter-panel" class="history-filter-panel">
                 <summary class="history-filter-summary">
                   <span class="history-filter-title">Filters</span>
@@ -300,6 +301,15 @@
                 </summary>
                 <div class="history-filter-body">
                   <div class="field-grid history-field-grid history-field-grid-records">
+                    <div class="field-stack">
+                      <label class="field-label" for="history-status-filter">Status</label>
+                      <select id="history-status-filter" class="field-select">
+                        <option value="all">All records</option>
+                        <option value="approved">Approved</option>
+                        <option value="denied">Denied</option>
+                        <option value="reopened">Reopened</option>
+                      </select>
+                    </div>
                     <div class="field-stack">
                       <label class="field-label" for="history-search-user">Username prefix</label>
                       <input id="history-search-user" class="field-input" type="text" placeholder="username (optional)" />

--- a/src/client/mod-panel.js
+++ b/src/client/mod-panel.js
@@ -83,6 +83,7 @@ import brandVxUrl from './brand-vx.png';
   const historyPanelRecords = document.getElementById('history-panel-records');
   const historyPanelApproved = document.getElementById('history-panel-approved');
   const historyPanelAudit = document.getElementById('history-panel-audit');
+  const historyStatusFilterSelect = document.getElementById('history-status-filter');
   const historySearchUserInput = document.getElementById('history-search-user');
   const historySearchHint = document.getElementById('history-search-hint');
   const historySearchFromInput = document.getElementById('history-search-from');
@@ -518,6 +519,12 @@ import brandVxUrl from './brand-vx.png';
   const statsCacheStale = {
     weekly: false,
     monthly: false,
+  };
+  const HISTORY_STATUS_FILTER_LABELS = {
+    all: 'All records',
+    approved: 'Approved',
+    denied: 'Denied',
+    reopened: 'Reopened',
   };
   const hiddenCriticalUpdateNoticeKeys = new Set();
   const APPROVAL_FLAIR_MANUAL_VALUE = '__manual__';
@@ -3270,6 +3277,9 @@ import brandVxUrl from './brand-vx.png';
 
   function getRecordsFilterActiveCount() {
     let count = 0;
+    if (historyStatusFilterSelect && historyStatusFilterSelect.value !== 'all') {
+      count += 1;
+    }
     if (historySearchUserInput && historySearchUserInput.value.trim()) {
       count += 1;
     }
@@ -5247,9 +5257,18 @@ import brandVxUrl from './brand-vx.png';
     const isMinLengthHintVisible = Boolean(historySearchHint && !historySearchHint.classList.contains('hidden'));
     if (!Array.isArray(historySearchItems) || historySearchItems.length === 0) {
       if (!isMinLengthHintVisible) {
-        renderEmptyState(historySearchResults, 'No history results', 'Search records by username prefix or date range.', {
-          icon: 'history',
-        });
+        const statusFilter = historyStatusFilterSelect ? String(historyStatusFilterSelect.value || 'all') : 'all';
+        const statusLabel = HISTORY_STATUS_FILTER_LABELS[statusFilter] || HISTORY_STATUS_FILTER_LABELS.all;
+        renderEmptyState(
+          historySearchResults,
+          'No history results',
+          statusFilter === 'all'
+            ? 'Search records by username prefix or date range.'
+            : `No ${statusLabel.toLowerCase()} records match these filters.`,
+          {
+            icon: 'history',
+          }
+        );
       }
     } else {
       for (const item of historySearchItems) {
@@ -7597,6 +7616,7 @@ import brandVxUrl from './brand-vx.png';
   function buildHistorySearchMessage(offset, requestId) {
     return {
       type: 'searchHistory',
+      status: historyStatusFilterSelect ? historyStatusFilterSelect.value : 'all',
       username: historySearchUserInput ? historySearchUserInput.value.trim() : '',
       fromDate: historySearchFromInput ? serializeDateInputBoundary(historySearchFromInput.value, false) : '',
       toDate: historySearchToInput ? serializeDateInputBoundary(historySearchToInput.value, true) : '',
@@ -7665,6 +7685,7 @@ import brandVxUrl from './brand-vx.png';
 
   function currentHistorySearchSignature() {
     return JSON.stringify({
+      status: historyStatusFilterSelect ? historyStatusFilterSelect.value : 'all',
       username: effectivePrefixSearchValue(historySearchUserInput ? historySearchUserInput.value : ''),
       fromDate: historySearchFromInput ? serializeDateInputBoundary(historySearchFromInput.value, false) : '',
       toDate: historySearchToInput ? serializeDateInputBoundary(historySearchToInput.value, true) : '',
@@ -8232,6 +8253,7 @@ import brandVxUrl from './brand-vx.png';
       historySearchItems = [];
       historySearchOffset = 0;
       historySearchHasMore = false;
+      if (historyStatusFilterSelect) historyStatusFilterSelect.value = 'all';
       if (historySearchUserInput) historySearchUserInput.value = '';
       applyDefaultDateRange(historySearchFromInput, historySearchToInput, HISTORY_DEFAULT_DAYS);
       setHistorySearchHintVisible(false);
@@ -8313,6 +8335,14 @@ import brandVxUrl from './brand-vx.png';
           runHistoryRecordsSearchWithInputGuard(true);
         }
       }, 300);
+    });
+  }
+  if (historyStatusFilterSelect) {
+    historyStatusFilterSelect.addEventListener('change', () => {
+      updateHistoryFilterSummaries();
+      if (activeHistoryView === 'records') {
+        runHistoryRecordsSearchWithInputGuard(true);
+      }
     });
   }
   if (historySearchFromInput) {

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -3802,6 +3802,99 @@ test('searchHistoryRecords treats short username prefixes as unfiltered baseline
   });
 });
 
+test('searchHistoryRecords filters approved denied and reopened records', async () => {
+  const reviewContext = createReviewActionContext();
+  const subredditId = reviewContext.subredditId;
+  const records = [
+    buildRecord({
+      id: 'history_approved',
+      username: 'approved_user',
+      subredditId,
+      subredditName: reviewContext.record.subredditName,
+      status: 'approved',
+      submittedAt: '2026-03-24T12:00:00.000Z',
+      ageAcknowledgedAt: '2026-03-24T12:00:00.000Z',
+      reviewedAt: '2026-03-25T12:00:00.000Z',
+      moderator: 'Mod_One',
+    }),
+    buildRecord({
+      id: 'history_denied',
+      username: 'denied_user',
+      subredditId,
+      subredditName: reviewContext.record.subredditName,
+      status: 'denied',
+      submittedAt: '2026-03-24T13:00:00.000Z',
+      ageAcknowledgedAt: '2026-03-24T13:00:00.000Z',
+      reviewedAt: '2026-03-25T13:00:00.000Z',
+      moderator: 'Mod_One',
+      denyReason: 'reason_1',
+    }),
+    buildRecord({
+      id: 'history_reopened_parent',
+      username: 'reopened_user',
+      subredditId,
+      subredditName: reviewContext.record.subredditName,
+      status: 'denied',
+      submittedAt: '2026-03-24T14:00:00.000Z',
+      ageAcknowledgedAt: '2026-03-24T14:00:00.000Z',
+      reviewedAt: '2026-03-25T14:00:00.000Z',
+      moderator: 'Mod_One',
+      denyReason: 'reason_2',
+    }),
+    buildRecord({
+      id: 'history_reopened_child',
+      username: 'reopened_user',
+      subredditId,
+      subredditName: reviewContext.record.subredditName,
+      status: 'pending',
+      submittedAt: '2026-03-26T12:00:00.000Z',
+      ageAcknowledgedAt: '2026-03-26T12:00:00.000Z',
+      parentVerificationId: 'history_reopened_parent',
+    }),
+  ];
+
+  for (const record of records) {
+    reviewContext.redisStore.set(verificationRecordTestKey(subredditId, record.id), JSON.stringify(record));
+    ensureTestZSet(reviewContext.zsetStore, historyDateIndexTestKey(subredditId)).set(
+      record.id,
+      new Date(String(record.reviewedAt || record.submittedAt)).getTime()
+    );
+  }
+  reviewContext.redisStore.set(
+    reopenedChildByDeniedTestKey(subredditId, 'history_reopened_parent'),
+    'history_reopened_child'
+  );
+  reviewContext.redisStore.set(reopenedStateByDeniedTestKey(subredditId, 'history_reopened_parent'), 'open');
+
+  await withFixedNow('2026-03-28T12:00:00.000Z', async () => {
+    const approved = await searchHistoryRecords(reviewContext.context as never, subredditId, {
+      status: 'approved',
+      fromDate: '2026-03-20T00:00:00.000Z',
+      offset: 0,
+      limit: 25,
+    });
+    const denied = await searchHistoryRecords(reviewContext.context as never, subredditId, {
+      status: 'denied',
+      fromDate: '2026-03-20T00:00:00.000Z',
+      offset: 0,
+      limit: 25,
+    });
+    const reopened = await searchHistoryRecords(reviewContext.context as never, subredditId, {
+      status: 'reopened',
+      fromDate: '2026-03-20T00:00:00.000Z',
+      offset: 0,
+      limit: 25,
+    });
+
+    assert.deepEqual(approved.items.map((item) => item.id), ['history_approved']);
+    assert.deepEqual(denied.items.map((item) => item.id), ['history_denied']);
+    assert.deepEqual(
+      reopened.items.map((item) => item.id).sort(),
+      ['history_reopened_child', 'history_reopened_parent']
+    );
+  });
+});
+
 test('searchApprovedRecords treats short username prefixes as unfiltered baseline queries', async () => {
   const reviewContext = createReviewActionContext({
     recordOverrides: {

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -147,10 +147,48 @@ export function toApprovedSearchPanelItem(record: VerificationRecord): ApprovedS
   };
 }
 
+type HistoryStatusFilter = 'all' | 'approved' | 'denied' | 'reopened';
+
+function normalizeHistoryStatusFilter(value: unknown): HistoryStatusFilter {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return normalized === 'approved' || normalized === 'denied' || normalized === 'reopened' ? normalized : 'all';
+}
+
+function isReopenedHistoryItem(item: HistorySearchPanelItem): boolean {
+  return Boolean(item.parentVerificationId?.trim()) || (item.status === 'denied' && item.reopenedState !== 'none');
+}
+
+function shouldConsiderRecordForHistoryStatusFilter(record: VerificationRecord, statusFilter: HistoryStatusFilter): boolean {
+  if (statusFilter === 'all') {
+    return true;
+  }
+  if (statusFilter === 'approved') {
+    return record.status === 'approved';
+  }
+  if (statusFilter === 'denied') {
+    return record.status === 'denied';
+  }
+  return record.status === 'denied' || Boolean(record.parentVerificationId?.trim());
+}
+
+function matchesHistoryStatusFilter(item: HistorySearchPanelItem, statusFilter: HistoryStatusFilter): boolean {
+  if (statusFilter === 'all') {
+    return true;
+  }
+  if (statusFilter === 'approved') {
+    return item.status === 'approved';
+  }
+  if (statusFilter === 'denied') {
+    return item.status === 'denied' && !isReopenedHistoryItem(item);
+  }
+  return isReopenedHistoryItem(item);
+}
+
 export async function searchHistoryRecords(
   context: Devvit.Context,
   subredditId: string,
   query: {
+    status?: string;
     username?: string;
     fromDate?: string;
     toDate?: string;
@@ -160,6 +198,7 @@ export async function searchHistoryRecords(
 ): Promise<HistorySearchResponsePayload> {
   const limit = Math.max(1, Math.min(50, Math.floor(query.limit ?? 25)));
   const offset = Math.max(0, Math.floor(query.offset ?? 0));
+  const statusFilter = normalizeHistoryStatusFilter(query.status);
   const usernameFilter = normalizeUsernamePrefixFilter(query.username, normalizeUsernameForLookup);
   const fromMs = parseSearchBoundaryMs(query.fromDate, false);
   const toMs = parseSearchBoundaryMs(query.toDate, true);
@@ -170,7 +209,7 @@ export async function searchHistoryRecords(
   }
 
   const baseKey = historyDateIndexKey(subredditId);
-  const candidateCount = limit * (usernameFilter ? 8 : 3);
+  const candidateCount = limit * (usernameFilter || statusFilter !== 'all' ? 8 : 3);
 
   const candidates = await context.redis.zRange(baseKey, minScore, maxScore, {
     by: 'score',
@@ -206,6 +245,9 @@ export async function searchHistoryRecords(
     if (usernameFilter && !normalizeUsernameForLookup(parsed.username).startsWith(usernameFilter)) {
       continue;
     }
+    if (!shouldConsiderRecordForHistoryStatusFilter(parsed, statusFilter)) {
+      continue;
+    }
     items.push({
       id: parsed.id,
       username: parsed.username,
@@ -220,7 +262,7 @@ export async function searchHistoryRecords(
       reopenedState: 'none',
       ...(parsed.status === 'approved' ? toSearchPhotoLinkFields(parsed) : {}),
     });
-    if (items.length >= limit) {
+    if ((statusFilter === 'all' || statusFilter === 'approved') && items.length >= limit) {
       break;
     }
   }
@@ -286,8 +328,12 @@ export async function searchHistoryRecords(
     }
   }
 
+  const filteredItems = statusFilter === 'all'
+    ? items
+    : items.filter((item) => matchesHistoryStatusFilter(item, statusFilter)).slice(0, limit);
+
   return {
-    items,
+    items: filteredItems,
     offset: offset + scannedCount,
     hasMore: scannedCount < candidates.length || candidates.length >= candidateCount,
     requestId: 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1303,6 +1303,7 @@ app.post('/api/mod/search/history', async (req, res) => {
     await requireReviewAccess(appContext);
     res.json(
       await searchHistoryRecords(appContext, sanitizeSubredditId(appContext.subredditId), {
+        status: String(req.body?.status ?? '').trim(),
         username: String(req.body?.username ?? '').trim(),
         fromDate: String(req.body?.fromDate ?? '').trim(),
         toDate: String(req.body?.toDate ?? '').trim(),


### PR DESCRIPTION
## What changed

- Add server-side status filtering for history records.
- Treat Verified members as an approved-record shortcut within the history workspace.
- Improve history navigation labels and filter state handling.
- Add regression coverage for approved, denied, and reopened status filters.

## Why

The separate approved/history experiences duplicated navigation and made it harder for moderators to move between verification outcomes consistently.

## Impact

Moderators get a clearer history workflow with status-aware filtering and a direct Verified members shortcut.

## Validation

- `npm run check`
- `npm test`
- `npm run build`
- Conflict-tested together with `fix/search`