### PR TITLE
improve photo instruction review flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Workflow demos:
 
 ## Quick Setup
 
-Follow the onboarding wizard that runs through the steps below:
+Onboarding wizard automatically runs through setup.  
 
+Manual Steps:
 1. Install VouchX in your subreddit  
 2. Run **Create Verification Hub (VouchX)** from the mod menu  
 3. Open the hub post → click **Mod Panel**  
@@ -66,7 +67,8 @@ Follow the onboarding wizard that runs through the steps below:
 Track moderator activity and verification volume.
 
 - **Currently Verified** = users approved right now  
-- **Approvals / Denials** = actions during the selected time range  
+- **Approvals / Denials** = actions during the selected time range 
+- **Decision Time & Reason usage** = how long it takes to action verifications
 
 *Note: Counts may change due to removals, expirations, or cleanup.*
 
@@ -111,7 +113,7 @@ Full changelog:
 [https://www.reddit.com/r/vouchx/wiki/changelog/](https://www.reddit.com/r/vouchx/wiki/changelog/)
 
 
-### v1.5.6
+### v1.5.7
 
 #### New Features
 - Added a Denial tag to queue cards. Tap it to view the most recent denial details.
@@ -141,26 +143,4 @@ Full changelog:
 - Fixes an issue where the auto flair repair could silently skip approved users verified before VouchX v1.3.0
 - TTL for newly approved records extended to 180 days to better support members who browse infrequently. Records for previously approved users are unaffected.
 - New Setup and Moderator onboarding wizard. 
-
----
-
-### v1.5.1
-
-#### UI Changes
-
-- Updated the Verification Hub with a more modern, easier-to-understand interface, including larger text, clearer timelines, and improved mobile spacing.
-- Mod Panel UI overhaul: Queue cards now show multiple photos on mobile, card details are simplified, and actions are easier to scan.
-- Denial flow improved: denial reason and moderator notes are shown after pressing Deny the first time, reducing clutter on queue cards.
-- Settings experience streamlined with cleaner navigation, lighter section structure, unified theme styling, and improved template editing.
-- Photo instructions are now optimized for mobile review, with improved language picker behavior and better use of available space.
-- Added optional verification requirement setting for communicating sub-level posting / commenting restrictions.
-- Updated VouchX branding with the new VX logo treatment for the hub, loading state, and app/profile icon.
-- Improved the hub loading experience with a branded loading state for inline Reddit views.
-
-#### Technical Changes
-
-- Updated VouchX to Devvit 0.13.0 and the current Devvit Web app structure.
-- Improved handling of transient Reddit/Devvit transport errors, including GOAWAY, cancelled calls, and retry-exhausted responses.
-- Improved moderator permission lookup resilience with retry behavior before falling back to cached permissions.
-- Updated queue lock TTL behavior.
 

--- a/README.md
+++ b/README.md
@@ -113,23 +113,24 @@ Full changelog:
 [https://www.reddit.com/r/vouchx/wiki/changelog/](https://www.reddit.com/r/vouchx/wiki/changelog/)
 
 
-### v1.5.7
+### v1.5.8
 
 #### New Features
-- Added a Denial tag to queue cards. Tap it to view the most recent denial details.
-- Added Peer Review, allowing moderators to flag a submission for a second opinion. Moderators can exchange review comments that are visible only to the moderation team.
-- Added Block Notes support.
-- Added new statistics:
-  - Average approval time tracking
-  - Denials by reason
+- Added **Denied Before** and **Denied ×N** badges to queue cards. Select a badge to view details from previous denials.
+- Added **Peer Review**, allowing moderators to request a second opinion and exchange moderator-only review comments.
+- Added support for **Block Notes**.
+- Added new moderator statistics:
+  - **90% Decided Within** decision-time tracking
+  - Denial breakdowns by reason
 
 #### Improvements
-- When a submission contains multiple photos, you can now swipe left or right while viewing an enlarged image to move between photos.
-- Removed Terms Accepted and Age Confirmed timestamps from queue cards to reduce clutter. This information is still retained internally for auditing and tracking purposes.
-- Improved Android photo instructions behavior.
-- Fixed wizard completion behavior, added exit button to prevent loops and added support for new features in wizard.
-- Search behavior for audit records improved for subs with larger history
-- Renamed Approved Records to "Verified Users"
+- Submissions with multiple photos can now be browsed by swiping left or right in the enlarged image viewer.
+- Removed **Terms Accepted** and **Age Confirmed** timestamps from queue cards to reduce clutter. This information remains stored for audit and tracking purposes.
+- Improved the Android photo-instructions flow, including a confirmation prompt when instructions were reviewed recently.
+- Improved wizard completion behavior, added an exit option to prevent navigation loops, and added support for introducing newly released features.
+- Improved audit-record search performance for communities with larger histories.
+- Renamed **Approved Records** to **Verified Users**.
+- Fixed photo-instruction scrolling on iOS 27.
 
 ---
 

--- a/src/client/hub-app.js
+++ b/src/client/hub-app.js
@@ -233,6 +233,23 @@ function createShell(root, inline) {
         </div>
       </div>
 
+      <div data-el="photo-instructions-review-modal" class="hub-modal hub-confirmation-modal hidden">
+        <div class="hub-modal-card" role="dialog" aria-modal="true" aria-labelledby="photo-instructions-review-title">
+          <h2 id="photo-instructions-review-title">Review photo instructions?</h2>
+          <p class="meta">
+            Make sure your photos follow the community’s verification requirements before submitting.
+          </p>
+          <label class="warning-check hub-photo-instructions-review-check">
+            <input data-el="photo-instructions-review-acknowledgement" type="checkbox" />
+            <span>I have reviewed the instructions and my submission follows them.</span>
+          </label>
+          <div class="row">
+            <button data-el="photo-instructions-review-view" class="btn-secondary" type="button">View Instructions</button>
+            <button data-el="photo-instructions-review-continue" class="btn-primary" type="button" disabled>Continue to Submit</button>
+          </div>
+        </div>
+      </div>
+
       <div data-el="photo-instructions-modal" class="hub-modal hidden">
         <div class="hub-modal-card hub-photo-card">
           <ol data-el="photo-instructions-flow" class="hub-flow" aria-label="Verification steps">
@@ -323,6 +340,12 @@ function createShell(root, inline) {
     submitWarningLinks: root.querySelector('[data-el="submit-warning-links"]'),
     submitWarningCancel: root.querySelector('[data-el="submit-warning-cancel"]'),
     submitWarningContinue: root.querySelector('[data-el="submit-warning-continue"]'),
+    photoInstructionsReviewModal: root.querySelector('[data-el="photo-instructions-review-modal"]'),
+    photoInstructionsReviewAcknowledgement: root.querySelector(
+      '[data-el="photo-instructions-review-acknowledgement"]'
+    ),
+    photoInstructionsReviewView: root.querySelector('[data-el="photo-instructions-review-view"]'),
+    photoInstructionsReviewContinue: root.querySelector('[data-el="photo-instructions-review-continue"]'),
     photoInstructionsModal: root.querySelector('[data-el="photo-instructions-modal"]'),
     photoInstructionsFlow: root.querySelector('[data-el="photo-instructions-flow"]'),
     photoInstructionsEyebrow: root.querySelector('[data-el="photo-instructions-eyebrow"]'),
@@ -902,6 +925,7 @@ export function mountHub(options = {}) {
   let flairPropagationRefreshKey = '';
   let developerPanelDraft = null;
   let photoInstructionsOnlyHandled = false;
+  let photoInstructionsReviewPromptOpen = false;
   const howToUseUrl = normalizeExternalUrl(HOW_TO_USE_APP_URL);
   const moderatorQuickStartUrl = normalizeExternalUrl(MODERATOR_QUICK_START_URL);
   const legalLinks = [
@@ -1337,6 +1361,10 @@ export function mountHub(options = {}) {
           window.location.replace(buildInternalNavigationUrl('./photo-instructions.html'));
           return;
         }
+        const continueToSubmission = await requestRecentPhotoInstructionsReview();
+        if (!continueToSubmission) {
+          return;
+        }
       } else {
         const continueToSubmission = await requestPhotoInstructionsReview({ requireContinue: true });
         if (!continueToSubmission) {
@@ -1427,6 +1455,66 @@ export function mountHub(options = {}) {
         refs.submitWarningContinue.disabled = true;
         refs.submitWarningContinue.title = 'Verification submissions are disabled in r/vouchx. This subreddit is for demonstration purposes only.';
       }
+    });
+  }
+
+  function requestRecentPhotoInstructionsReview() {
+    return new Promise((resolve) => {
+      if (
+        photoInstructionsReviewPromptOpen ||
+        !refs.photoInstructionsReviewModal ||
+        !refs.photoInstructionsReviewAcknowledgement ||
+        !refs.photoInstructionsReviewView ||
+        !refs.photoInstructionsReviewContinue
+      ) {
+        resolve(false);
+        return;
+      }
+
+      photoInstructionsReviewPromptOpen = true;
+      refs.photoInstructionsReviewAcknowledgement.checked = false;
+      refs.photoInstructionsReviewContinue.disabled = true;
+
+      const close = (continueToSubmission) => {
+        refs.photoInstructionsReviewModal.classList.add('hidden');
+        refs.photoInstructionsReviewAcknowledgement.removeEventListener('change', onAcknowledgementChange);
+        refs.photoInstructionsReviewView.removeEventListener('click', onViewInstructions);
+        refs.photoInstructionsReviewContinue.removeEventListener('click', onContinueToSubmit);
+        refs.photoInstructionsReviewModal.removeEventListener('click', onBackdrop);
+        refs.photoInstructionsReviewAcknowledgement.checked = false;
+        refs.photoInstructionsReviewContinue.disabled = true;
+        photoInstructionsReviewPromptOpen = false;
+        resolve(continueToSubmission);
+      };
+
+      const onAcknowledgementChange = () => {
+        refs.photoInstructionsReviewContinue.disabled = !refs.photoInstructionsReviewAcknowledgement.checked;
+      };
+
+      const onViewInstructions = (event) => {
+        markPhotoInstructionsRead();
+        close(false);
+        openPhotoInstructionsModal(event);
+      };
+
+      const onContinueToSubmit = () => {
+        if (!refs.photoInstructionsReviewAcknowledgement.checked) {
+          return;
+        }
+        close(true);
+      };
+
+      const onBackdrop = (event) => {
+        if (event.target === refs.photoInstructionsReviewModal) {
+          close(false);
+        }
+      };
+
+      refs.photoInstructionsReviewAcknowledgement.addEventListener('change', onAcknowledgementChange);
+      refs.photoInstructionsReviewView.addEventListener('click', onViewInstructions);
+      refs.photoInstructionsReviewContinue.addEventListener('click', onContinueToSubmit);
+      refs.photoInstructionsReviewModal.addEventListener('click', onBackdrop);
+      refs.photoInstructionsReviewModal.classList.remove('hidden');
     });
   }
 

--- a/src/client/hub-ui.css
+++ b/src/client/hub-ui.css
@@ -1560,6 +1560,11 @@ button:not(:disabled):hover {
   scrollbar-gutter: stable;
 }
 
+[data-el="photo-instructions-modal"] .hub-modal-copy,
+[data-el="photo-instructions-modal"] .hub-modal-copy * {
+  touch-action: pan-y !important;
+}
+
 .hub-scroll-hint {
   position: absolute;
   display: inline-flex;

--- a/src/client/hub-ui.css
+++ b/src/client/hub-ui.css
@@ -1604,6 +1604,10 @@ button:not(:disabled):hover {
   margin: 3px 0 0;
 }
 
+.hub-photo-instructions-review-check {
+  margin-top: 16px;
+}
+
 .legal-links-modal {
   justify-content: flex-start;
   padding-top: 12px;
@@ -1667,6 +1671,10 @@ button:not(:disabled):hover {
     align-items: flex-start;
     overflow-y: auto;
     padding: 12px;
+  }
+
+  .hub-modal.hub-confirmation-modal {
+    align-items: center;
   }
 
   .hub-modal-card {


### PR DESCRIPTION
## What changed

- Show Android users a lightweight review confirmation when photo instructions were viewed within the existing guard window.
- Require the in-dialog acknowledgement checkbox before enabling **Continue to Submit**.
- Reuse the existing Android-compatible dedicated instruction view from **View Instructions**.
- Restore vertical touch scrolling inside the photo-instructions content when Reddit injects a global `touch-action: pan-x !important` rule.
- Refresh the README onboarding/release notes already included on this branch.

The Android guard previously skipped directly to submission agreements, leaving no opportunity to revisit instructions. Separately, iOS 27 began honoring Reddit’s injected horizontal-only touch-action rule in a way that prevented vertical scrolling inside the instruction modal.

## Validation

- `npm run check`
- `npm test` — 215 tests passed
- `npm run build`
- Rebasing onto current `origin/main` removed a patch-identical duplicate commit.
- Virtual merge against `main` completed without conflicts.
